### PR TITLE
fix(plugins): correct powercat-adoption identity and complete marketplace catalog (#8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,41 +5,111 @@
     "name": "Microsoft Power CAT"
   },
   "description": "Power Platform development extensions curated by Microsoft Power CAT (Customer Advisory Team)",
-  "plugins": [    
+  "plugins": [
     {
-       "name": "powercat-canvas-apps",
-       "description": "Skills to analyze Canvas App performance and guide migrations from InfoPath and SharePoint to modern Power Platform.",
-       "source": "./plugins/powercat-canvas-apps",
-       "skills": [
-         "./plugins/powercat-canvas-apps/skills/analyze-canvas-performance",
-         "./plugins/powercat-canvas-apps/skills/infopath-to-canvas",
-         "./plugins/powercat-canvas-apps/skills/migrate-to-dataverse"
-       ],
-       "version": "1.0.7",
-       "repository": "https://github.com/microsoft/power-cat-skills",
-       "license": "MIT",
-       "category": "development",
-       "tags": [
-         "canvas apps", "power platform", "power apps",
-         "infopath", "dataverse", "performance",
-         "microsoft power platform", "microsoft"
-       ]
-     },
-     {
-       "name": "powercat-code-apps",
-       "description": "Skills to generate brand-aligned design guides for code apps built on the Power Platform.",
-       "source": "./plugins/powercat-code-apps",
-       "skills": [
-         "./plugins/powercat-code-apps/skills/design-guide"
-       ],
-       "version": "1.0.0",
-       "repository": "https://github.com/microsoft/power-cat-skills",
-       "license": "MIT",
-       "category": "development",
-       "tags": [
-         "code apps", "power platform", "power apps",
-         "design guide", "brand", "microsoft"
-       ]
-     }
+      "name": "powercat-canvas-apps",
+      "description": "Skills to analyze Canvas App performance and guide migrations from InfoPath and SharePoint to modern Power Platform.",
+      "source": "./plugins/powercat-canvas-apps",
+      "skills": [
+        "./plugins/powercat-canvas-apps/skills/analyze-canvas-performance",
+        "./plugins/powercat-canvas-apps/skills/infopath-to-canvas",
+        "./plugins/powercat-canvas-apps/skills/migrate-to-dataverse"
+      ],
+      "version": "1.0.7",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "canvas apps",
+        "power platform",
+        "power apps",
+        "infopath",
+        "dataverse",
+        "performance",
+        "microsoft power platform",
+        "microsoft"
+      ]
+    },
+    {
+      "name": "powercat-code-apps",
+      "description": "Skills to generate brand-aligned design guides for code apps built on the Power Platform.",
+      "source": "./plugins/powercat-code-apps",
+      "skills": [
+        "./plugins/powercat-code-apps/skills/design-guide"
+      ],
+      "version": "1.0.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "code apps",
+        "power platform",
+        "power apps",
+        "design guide",
+        "brand",
+        "microsoft"
+      ]
+    },
+    {
+      "name": "powercat-dataverse",
+      "description": "Skills to author and ship Dataverse Web API queries (OData/FetchXML) across Generative Pages, Code Apps, Xrm.WebApi, Canvas, and Power Automate.",
+      "source": "./plugins/powercat-dataverse",
+      "skills": [
+        "./plugins/powercat-dataverse/skills/dataverse-webapi-query",
+        "./plugins/powercat-dataverse/skills/powercat-storytelling"
+      ],
+      "version": "1.0.7",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "dataverse",
+        "power platform",
+        "webapi",
+        "odata",
+        "fetchxml",
+        "microsoft"
+      ]
+    },
+    {
+      "name": "powercat-governance",
+      "description": "Skills for Power Platform governance and administration -- provision developer environments with standard governance defaults.",
+      "source": "./plugins/powercat-governance",
+      "skills": [
+        "./plugins/powercat-governance/skills/create-pp-dev-env"
+      ],
+      "version": "1.0.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "governance",
+        "power platform",
+        "admin",
+        "developer environment",
+        "managed environment",
+        "microsoft"
+      ]
+    },
+    {
+      "name": "powercat-adoption",
+      "description": "Skills for Power Platform adoption -- generate polished, brand-matched customer story decks and other adoption assets.",
+      "source": "./plugins/powercat-adoption",
+      "skills": [
+        "./plugins/powercat-adoption/skills/powercat-storytelling"
+      ],
+      "version": "1.0.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "adoption",
+        "power platform",
+        "storytelling",
+        "customer story",
+        "presentation",
+        "microsoft"
+      ]
+    }
   ]
 }

--- a/plugins/powercat-adoption/.claude-plugin/plugin.json
+++ b/plugins/powercat-adoption/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "powercat-canvas-apps",
-  "version": "1.0.7",
-  "description": "Claude skills to analyze Canvas App performance and guide migrations from InfoPath and SharePoint to modern Power Platform architectures using Power Apps and Dataverse.",
+  "name": "powercat-adoption",
+  "version": "1.0.0",
+  "description": "Claude skills for Power Platform adoption -- generate polished, brand-matched customer story decks and other adoption assets.",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"
@@ -10,10 +10,10 @@
   "repository": "https://github.com/microsoft/power-cat-skills/",
   "license": "MIT",
   "keywords": [
-    "canvas-apps",
-    "power-apps",
-    "canvas",
-    "pa-yaml",
-    "msapp"
+    "adoption",
+    "power-platform",
+    "storytelling",
+    "customer-story",
+    "presentation"
   ]
 }

--- a/plugins/powercat-dataverse/.claude-plugin/plugin.json
+++ b/plugins/powercat-dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "powercat-dataverse",
   "version": "1.0.7",
-  "description": "Claude skills to Dataverse operations and features.",
+  "description": "Claude skills for Dataverse -- author and ship Dataverse Web API queries (OData / FetchXML) for Generative Pages, Code Apps, Xrm.WebApi, Canvas, and Power Automate.",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"
@@ -10,10 +10,10 @@
   "repository": "https://github.com/microsoft/power-cat-skills/",
   "license": "MIT",
   "keywords": [
-    "canvas-apps",
-    "power-apps",
-    "canvas",
-    "pa-yaml",
-    "msapp"
+    "dataverse",
+    "power-platform",
+    "webapi",
+    "odata",
+    "fetchxml"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes #8.

**Root cause.** `plugins/powercat-adoption/.claude-plugin/plugin.json` was a copy of the `powercat-canvas-apps` manifest -- so the `"name"` field said `powercat-canvas-apps`, and any direct install of `powercat-adoption` either failed (when looked up by name in the marketplace catalog) or silently collided with the canvas-apps plugin (when installed directly from the folder).

Two related symptoms reported in the issue:
1. `copilot plugin install powercat-adoption@power-cat-skills` fails with `Plugin 'powercat-adoption' not found in marketplace 'power-cat-skills'`.
2. Direct install registers the plugin as `powercat-canvas-apps` and overwrites the real canvas-apps install.

The first symptom has a second root cause: `.claude-plugin/marketplace.json` only lists `powercat-canvas-apps` and `powercat-code-apps`, even though the README advertises four installable plugins (canvas-apps, dataverse, governance, adoption).

## Changes

| File | Change |
|---|---|
| `plugins/powercat-adoption/.claude-plugin/plugin.json` | Replace the canvas-apps copy with the real adoption identity (`name`, `description`, `keywords`) matching the `powercat-storytelling` skill it ships. |
| `plugins/powercat-dataverse/.claude-plugin/plugin.json` | Replace the remaining canvas-apps `keywords` copy-paste with dataverse-relevant keywords and tighten the description. The `name` field was already correct. |
| `.claude-plugin/marketplace.json` | Add `powercat-dataverse`, `powercat-governance`, and `powercat-adoption` entries so all four plugins advertised in the README are actually installable via `@power-cat-skills`. |

Descriptions, skill lists, and version numbers are taken from the existing plugin folders and the README table.

## Verification

After this change:
- `copilot plugin install powercat-adoption@power-cat-skills` resolves to the adoption plugin (not canvas-apps).
- Each marketplace entry points at a real `plugins/<name>/skills/<skill>` directory in this repo.
- `powercat-canvas-apps` and `powercat-code-apps` entries are unchanged.

## Out of scope (flagged for follow-up)

- `plugins/powercat-procode-eval/.claude-plugin/plugin.json` does not exist at all -- the folder ships `eval-generator-code-app` and `eval-generator-gen-pages` skills but is not a registerable plugin yet. This PR does not add it because the issue scope is limited to the three README-advertised plugins. Happy to follow up in a separate PR if you want it added to the marketplace catalog too.
