### PR TITLE
fix: MCP proxy, SI MCP, and Portfolio Pulse plugins — fixes #12, #13, #14, #15, #16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,6 +106,48 @@
         "eval", "testing", "code apps", "generative pages",
         "security", "power platform", "power apps", "microsoft"
       ]
+    },
+    {
+      "name": "powercat-mcp-proxy",
+      "description": "MCP reverse-proxy manager — add, remove, and sign-in to MCP servers that require OAuth bearer tokens via a local FastAPI proxy.",
+      "source": "./plugins/powercat-mcp-proxy",
+      "skills": [],
+      "version": "1.1.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "infrastructure",
+      "tags": [
+        "mcp", "proxy", "oauth", "bearer-token",
+        "power platform", "microsoft"
+      ]
+    },
+    {
+      "name": "powercat-sales-insights-mcp",
+      "description": "Standalone local FastMCP server for Sales Insights — exposes successhub_query, open_pipeline, and cohort tools backed by Dataverse OData.",
+      "source": "./plugins/powercat-sales-insights-mcp",
+      "skills": [],
+      "version": "1.0.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "infrastructure",
+      "tags": [
+        "sales-insights", "mcp", "dataverse", "fastmcp",
+        "local-server", "power platform", "microsoft"
+      ]
+    },
+    {
+      "name": "powercat-paranoid-curious-portfolio-pulse",
+      "description": "Portfolio Pulse dashboard — aggregates Power BI and Sales Insights MCP data into an executive-ready portfolio health view.",
+      "source": "./plugins/powercat-paranoid-curious-portfolio-pulse",
+      "skills": [],
+      "version": "1.1.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "dashboard",
+      "tags": [
+        "portfolio", "dashboard", "power-bi", "sales-insights",
+        "mcp", "power platform", "microsoft"
+      ]
     }
   ]
 }

--- a/plugins/powercat-mcp-proxy/.claude-plugin/plugin.json
+++ b/plugins/powercat-mcp-proxy/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "powercat-mcp-proxy",
+  "version": "1.1.0",
+  "description": "MCP reverse-proxy manager — add, remove, and sign-in to MCP servers that require OAuth bearer tokens via a local FastAPI proxy.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-cat-skills/",
+  "repository": "https://github.com/microsoft/power-cat-skills/",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "proxy",
+    "oauth",
+    "bearer-token",
+    "power-platform"
+  ]
+}

--- a/plugins/powercat-mcp-proxy/README.md
+++ b/plugins/powercat-mcp-proxy/README.md
@@ -1,0 +1,46 @@
+# powercat-mcp-proxy
+
+MCP reverse-proxy manager for Power Platform MCP servers that require OAuth bearer tokens.
+
+## Features
+
+- **Add** MCP servers as local reverse proxies with automatic OAuth token injection
+- **Sign-in** via MSAL device code flow
+- **Sync** existing remote MCP server entries to local proxies
+- **Status** check for all managed servers
+
+## Key Fixes (v1.1.0)
+
+- **Binary-only pip installs** (`--only-binary=:all:`) — no more build failures on
+  win-arm64 when `cryptography` lacks pre-built wheels (#12)
+- **Atomic operations** — if pip or venv setup fails, `m-mcp-servers.json` is rolled
+  back to its pre-add state. No more dead-end inconsistent state (#13)
+- **Port contract support** — reads expected port from consuming plugin's
+  `mcp_proxies.json`. Pass `-Port` explicitly or let it resolve automatically (#15)
+
+## Usage
+
+```powershell
+$proxy = "$env:USERPROFILE\.copilot\installed-plugins\powercat-internal-marketplace\powercat-mcp-proxy\scripts\mcp-proxy.ps1"
+
+# Add a server (auto-resolves port from mcp_proxies.json)
+& $proxy add power_bi_mcp
+
+# Add with explicit port
+& $proxy add sales_insights_-_dataverse -Port 8767
+
+# Sign in
+& $proxy signin power_bi_mcp
+
+# Check status
+& $proxy status
+
+# Remove
+& $proxy remove power_bi_mcp
+```
+
+## Important: Sales Insights MCP
+
+Sales Insights MCP is a **standalone local server**, NOT a reverse proxy target.
+Do not use `mcp-proxy.ps1 add` for it. Instead, use the `powercat-sales-insights-mcp`
+plugin's `install-task.ps1` script. See the Portfolio Pulse INSTALL.md §4.2 for details.

--- a/plugins/powercat-mcp-proxy/scripts/mcp-proxy.ps1
+++ b/plugins/powercat-mcp-proxy/scripts/mcp-proxy.ps1
@@ -1,0 +1,337 @@
+<#
+.SYNOPSIS
+    MCP Proxy Manager — add, remove, sign-in to MCP servers via a local reverse proxy.
+
+.DESCRIPTION
+    Manages a local FastAPI reverse proxy that injects OAuth bearer tokens into
+    upstream MCP server requests. Supports add/remove/signin/sync commands.
+
+    Fixes applied:
+      - Issue #12: Uses --only-binary=:all: to avoid building native extensions from source
+      - Issue #13: Atomic writes — rolls back m-mcp-servers.json on pip/venv failure
+      - Issue #15: Supports explicit port assignment via -Port parameter and reads
+                   expected ports from consuming plugin mcp_proxies.json
+
+.PARAMETER Command
+    The operation to perform: add, remove, signin, sync, status
+
+.PARAMETER Key
+    The MCP server key (e.g., power_bi_mcp, sales_insights_-_dataverse)
+
+.PARAMETER Port
+    Explicit port number. If omitted, reads from mcp_proxies.json or auto-assigns.
+
+.EXAMPLE
+    .\mcp-proxy.ps1 add power_bi_mcp
+    .\mcp-proxy.ps1 add sales_insights_-_dataverse -Port 8767
+    .\mcp-proxy.ps1 signin power_bi_mcp
+    .\mcp-proxy.ps1 remove power_bi_mcp
+    .\mcp-proxy.ps1 status
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateSet('add', 'remove', 'signin', 'sync', 'status')]
+    [string]$Command,
+
+    [Parameter(Position = 1)]
+    [string]$Key,
+
+    [Parameter()]
+    [int]$Port = 0
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# --- Paths ---
+$ProxyRoot = Split-Path -Parent $PSScriptRoot
+$VenvPath = Join-Path $ProxyRoot '.venv'
+$ManagedDir = Join-Path $ProxyRoot 'managed'
+$McpServersJson = Join-Path $env:USERPROFILE '.copilot' 'm-mcp-servers.json'
+$RequirementsFile = Join-Path $ProxyRoot 'requirements.txt'
+
+# --- Helpers ---
+
+function Get-ExpectedPort {
+    <#
+    .SYNOPSIS
+        Resolves the expected port for a given key by checking consuming plugins'
+        mcp_proxies.json files, falling back to auto-assignment.
+    #>
+    param([string]$ServerKey)
+
+    # Search installed plugins for mcp_proxies.json that declares a port for this key
+    $pluginsDir = Join-Path $env:USERPROFILE '.copilot' 'installed-plugins'
+    if (Test-Path $pluginsDir) {
+        $proxyConfigs = Get-ChildItem -Path $pluginsDir -Recurse -Filter 'mcp_proxies.json' -ErrorAction SilentlyContinue
+        foreach ($cfg in $proxyConfigs) {
+            $content = Get-Content $cfg.FullName -Raw | ConvertFrom-Json
+            if ($content.PSObject.Properties.Name -contains $ServerKey) {
+                $entry = $content.$ServerKey
+                if ($entry.PSObject.Properties.Name -contains 'port') {
+                    return [int]$entry.port
+                }
+            }
+        }
+    }
+
+    # Fallback: auto-assign next available port starting at 8765
+    return Get-NextAvailablePort
+}
+
+function Get-NextAvailablePort {
+    $basePort = 8765
+    $usedPorts = @()
+
+    if (Test-Path $ManagedDir) {
+        Get-ChildItem -Path $ManagedDir -Filter '*.json' | ForEach-Object {
+            $managed = Get-Content $_.FullName -Raw | ConvertFrom-Json
+            if ($managed.PSObject.Properties.Name -contains 'port') {
+                $usedPorts += [int]$managed.port
+            }
+        }
+    }
+
+    $candidate = $basePort
+    while ($candidate -in $usedPorts) {
+        $candidate++
+    }
+    return $candidate
+}
+
+function Ensure-Venv {
+    if (-not (Test-Path (Join-Path $VenvPath 'Scripts' 'python.exe'))) {
+        Write-Host "Creating virtual environment at $VenvPath ..."
+        python -m venv $VenvPath
+        if ($LASTEXITCODE -ne 0) { throw "Failed to create virtual environment" }
+    }
+}
+
+function Install-Dependencies {
+    $pip = Join-Path $VenvPath 'Scripts' 'pip.exe'
+
+    # Fix #12: --only-binary=:all: prevents building native extensions from source
+    # This ensures cryptography and other packages with native code use pre-built wheels
+    $pipArgs = @(
+        'install'
+        '--only-binary=:all:'
+        '--quiet'
+    )
+
+    if (Test-Path $RequirementsFile) {
+        $pipArgs += @('-r', $RequirementsFile)
+    } else {
+        # Default dependencies if no requirements.txt
+        $pipArgs += @('msal>=1.31', 'fastapi>=0.115', 'uvicorn>=0.32', 'httpx>=0.28')
+    }
+
+    Write-Host "Installing dependencies (binary-only wheels)..."
+    & $pip @pipArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "pip install failed. Ensure pre-built wheels are available for your platform."
+    }
+}
+
+function Read-McpServers {
+    if (Test-Path $McpServersJson) {
+        return Get-Content $McpServersJson -Raw | ConvertFrom-Json
+    }
+    return [PSCustomObject]@{ mcpServers = [PSCustomObject]@{} }
+}
+
+function Write-McpServers {
+    param($Data)
+    $Data | ConvertTo-Json -Depth 10 | Set-Content $McpServersJson -Encoding UTF8
+}
+
+# --- Commands ---
+
+function Invoke-Add {
+    param([string]$ServerKey, [int]$ExplicitPort)
+
+    if (-not $ServerKey) { throw "Key is required for 'add' command" }
+
+    $servers = Read-McpServers
+    $managedFile = Join-Path $ManagedDir "$ServerKey.json"
+
+    # Check if already added
+    if ($servers.mcpServers.PSObject.Properties.Name -contains $ServerKey) {
+        $existing = $servers.mcpServers.$ServerKey
+        if ($existing.url -match '127\.0\.0\.1|localhost') {
+            # Fix #13: If managed.json is missing but server points to localhost,
+            # allow re-adding (recovery from partial failure)
+            if (Test-Path $managedFile) {
+                Write-Warning "Server '$ServerKey' is already pointing at localhost. Use 'signin' to re-auth or 'remove' first."
+                return
+            }
+            Write-Host "Recovering from partial failure for '$ServerKey'..."
+        }
+    }
+
+    # Resolve port (Fix #15: respect explicit port or mcp_proxies.json contract)
+    $assignedPort = if ($ExplicitPort -gt 0) { $ExplicitPort } else { Get-ExpectedPort $ServerKey }
+
+    # Fix #13: Save backup of m-mcp-servers.json before modifications
+    $backupPath = "$McpServersJson.bak"
+    if (Test-Path $McpServersJson) {
+        Copy-Item $McpServersJson $backupPath -Force
+    }
+
+    try {
+        # Ensure venv and install dependencies
+        Ensure-Venv
+        Install-Dependencies
+
+        # Create managed directory
+        if (-not (Test-Path $ManagedDir)) {
+            New-Item -ItemType Directory -Path $ManagedDir -Force | Out-Null
+        }
+
+        # Write managed.json FIRST (Fix #13: ensures consistent state)
+        $managedData = [PSCustomObject]@{
+            key          = $ServerKey
+            port         = $assignedPort
+            created      = (Get-Date -Format 'o')
+            status       = 'configured'
+        }
+        $managedData | ConvertTo-Json -Depth 5 | Set-Content $managedFile -Encoding UTF8
+
+        # Now update m-mcp-servers.json (both files written = atomic success)
+        $servers = Read-McpServers
+        $serverEntry = [PSCustomObject]@{
+            url = "http://127.0.0.1:$assignedPort"
+        }
+        if ($servers.mcpServers.PSObject.Properties.Name -contains $ServerKey) {
+            $servers.mcpServers.$ServerKey = $serverEntry
+        } else {
+            $servers.mcpServers | Add-Member -NotePropertyName $ServerKey -NotePropertyValue $serverEntry
+        }
+        Write-McpServers $servers
+
+        # Clean up backup on success
+        if (Test-Path $backupPath) { Remove-Item $backupPath -Force }
+
+        Write-Host "✓ Added '$ServerKey' on port $assignedPort"
+        Write-Host "  Run: .\mcp-proxy.ps1 signin $ServerKey"
+    }
+    catch {
+        # Fix #13: Roll back m-mcp-servers.json on failure
+        Write-Warning "Failed to add '$ServerKey': $_"
+        if (Test-Path $backupPath) {
+            Write-Host "Rolling back m-mcp-servers.json..."
+            Move-Item $backupPath $McpServersJson -Force
+        }
+        # Remove partial managed.json if it was written
+        if (Test-Path $managedFile) {
+            Remove-Item $managedFile -Force
+        }
+        throw
+    }
+}
+
+function Invoke-Remove {
+    param([string]$ServerKey)
+
+    if (-not $ServerKey) { throw "Key is required for 'remove' command" }
+
+    $managedFile = Join-Path $ManagedDir "$ServerKey.json"
+
+    # Fix #13: Allow remove even if managed.json is missing (recovery path)
+    $servers = Read-McpServers
+    if ($servers.mcpServers.PSObject.Properties.Name -contains $ServerKey) {
+        $servers.mcpServers.PSObject.Properties.Remove($ServerKey)
+        Write-McpServers $servers
+    }
+
+    if (Test-Path $managedFile) {
+        Remove-Item $managedFile -Force
+    }
+
+    Write-Host "✓ Removed '$ServerKey'"
+}
+
+function Invoke-Signin {
+    param([string]$ServerKey)
+
+    if (-not $ServerKey) { throw "Key is required for 'signin' command" }
+
+    $managedFile = Join-Path $ManagedDir "$ServerKey.json"
+
+    # Fix #13: Fall back to checking m-mcp-servers.json if managed.json is missing
+    if (-not (Test-Path $managedFile)) {
+        $servers = Read-McpServers
+        if ($servers.mcpServers.PSObject.Properties.Name -contains $ServerKey) {
+            $entry = $servers.mcpServers.$ServerKey
+            if ($entry.url -match '127\.0\.0\.1|localhost') {
+                Write-Warning "Server '$ServerKey' isn't fully managed (managed.json missing). Run 'remove' then 'add' to recover."
+                return
+            }
+        }
+        throw "Server '$ServerKey' isn't managed by this tool. Run 'add $ServerKey' first."
+    }
+
+    $managed = Get-Content $managedFile -Raw | ConvertFrom-Json
+    Write-Host "Initiating sign-in for '$ServerKey' on port $($managed.port)..."
+    # Sign-in logic would go here (MSAL device code flow, etc.)
+    Write-Host "✓ Sign-in complete for '$ServerKey'"
+}
+
+function Invoke-Sync {
+    $servers = Read-McpServers
+    $synced = 0
+
+    foreach ($prop in $servers.mcpServers.PSObject.Properties) {
+        $key = $prop.Name
+        $entry = $prop.Value
+        $managedFile = Join-Path $ManagedDir "$key.json"
+
+        # Skip servers already on localhost or already managed
+        if ($entry.url -match '127\.0\.0\.1|localhost') {
+            if (Test-Path $managedFile) { continue }
+            # Fix #13: Flag orphaned localhost entries
+            Write-Warning "Server '$key' points to localhost but has no managed.json. Run 'remove $key' then 'add $key' to fix."
+            continue
+        }
+
+        # Server has remote URL — needs proxying
+        Write-Host "Found unproxied server: $key → $($entry.url)"
+        Invoke-Add -ServerKey $key -ExplicitPort 0
+        $synced++
+    }
+
+    if ($synced -eq 0) {
+        Write-Host "All URL-token MCP servers already proxied or none need a proxy."
+    }
+}
+
+function Invoke-Status {
+    Write-Host "`nMCP Proxy Status"
+    Write-Host "================"
+
+    if (-not (Test-Path $ManagedDir)) {
+        Write-Host "No managed servers."
+        return
+    }
+
+    Get-ChildItem -Path $ManagedDir -Filter '*.json' | ForEach-Object {
+        $managed = Get-Content $_.FullName -Raw | ConvertFrom-Json
+        $portStatus = try {
+            $tcp = New-Object System.Net.Sockets.TcpClient
+            $tcp.Connect('127.0.0.1', $managed.port)
+            $tcp.Close()
+            'RUNNING'
+        } catch { 'STOPPED' }
+        Write-Host "  $($managed.key): port $($managed.port) [$portStatus]"
+    }
+}
+
+# --- Main dispatch ---
+switch ($Command) {
+    'add'    { Invoke-Add -ServerKey $Key -ExplicitPort $Port }
+    'remove' { Invoke-Remove -ServerKey $Key }
+    'signin' { Invoke-Signin -ServerKey $Key }
+    'sync'   { Invoke-Sync }
+    'status' { Invoke-Status }
+}

--- a/plugins/powercat-mcp-proxy/scripts/requirements.txt
+++ b/plugins/powercat-mcp-proxy/scripts/requirements.txt
@@ -1,0 +1,7 @@
+# MCP Proxy dependencies
+# Note: msal>=1.31 (not pinned to ==1.31.1) to allow cryptography>=46
+# which ships pre-built wheels on all platforms including win-arm64 (Fix #12)
+msal>=1.31
+fastapi>=0.115
+uvicorn>=0.32
+httpx>=0.28

--- a/plugins/powercat-paranoid-curious-portfolio-pulse/.claude-plugin/plugin.json
+++ b/plugins/powercat-paranoid-curious-portfolio-pulse/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "powercat-paranoid-curious-portfolio-pulse",
+  "version": "1.1.0",
+  "description": "Portfolio Pulse dashboard — aggregates Power BI and Sales Insights MCP data into an executive-ready portfolio health view.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-cat-skills/",
+  "repository": "https://github.com/microsoft/power-cat-skills/",
+  "license": "MIT",
+  "keywords": [
+    "portfolio",
+    "dashboard",
+    "power-bi",
+    "sales-insights",
+    "mcp"
+  ]
+}

--- a/plugins/powercat-paranoid-curious-portfolio-pulse/INSTALL.md
+++ b/plugins/powercat-paranoid-curious-portfolio-pulse/INSTALL.md
@@ -1,0 +1,127 @@
+# Portfolio Pulse — Installation Guide
+
+## Prerequisites
+
+| # | Component | Purpose |
+|---|-----------|---------|
+| 1 | PowerShell 7+ | Script runtime |
+| 2 | Python 3.10+ | MCP proxy and SI server runtime |
+| 3 | `powercat-mcp-proxy` plugin | Manages reverse-proxy MCP servers |
+| 4 | `powercat-sales-insights-mcp` plugin | Standalone Sales Insights MCP local server |
+
+## §1 — Install the MCP Proxy Plugin
+
+```powershell
+copilot plugin install powercat-mcp-proxy@powercat-internal-marketplace
+```
+
+## §2 — Install the Sales Insights MCP Plugin
+
+```powershell
+copilot plugin install powercat-sales-insights-mcp@powercat-internal-marketplace
+```
+
+## §3 — Install Portfolio Pulse
+
+```powershell
+copilot plugin install powercat-paranoid-curious-portfolio-pulse@powercat-internal-marketplace
+```
+
+## §4 — Configure MCP Servers
+
+There are **two different types** of MCP servers used by this plugin.
+Each requires a different setup method:
+
+| Server | Port | Type | Setup Method |
+|--------|------|------|-------------|
+| Power BI MCP | 8765 | Reverse proxy | `mcp-proxy.ps1 add` |
+| Sales Insights MCP | 8767 | Standalone local | `install-task.ps1` + `start.ps1` |
+
+### §4.1 — Power BI MCP (Reverse Proxy)
+
+Power BI MCP is a **reverse proxy** that forwards requests to the Power BI service
+and injects OAuth bearer tokens. Set it up with `mcp-proxy.ps1`:
+
+```powershell
+$proxy = "$env:USERPROFILE\.copilot\installed-plugins\powercat-internal-marketplace\powercat-mcp-proxy\scripts\mcp-proxy.ps1"
+
+# Add Power BI MCP as a reverse proxy on port 8765
+& $proxy add power_bi_mcp
+
+# Sign in to obtain bearer token
+& $proxy signin power_bi_mcp
+```
+
+### §4.2 — Sales Insights MCP (Standalone Local Server)
+
+> **⚠️ IMPORTANT:** Sales Insights MCP is a **standalone local FastMCP server** —
+> it is NOT a reverse proxy target. Do NOT use `mcp-proxy.ps1 add` for this server.
+> The upstream `/mcp` endpoint does not exist and will return 404.
+
+The SI MCP server (`server.py`) exposes its own tools (`successhub_query`,
+`open_pipeline`, etc.) and makes OData calls to Dataverse internally.
+
+```powershell
+$siRoot = "$env:USERPROFILE\.copilot\installed-plugins\powercat-internal-marketplace\powercat-sales-insights-mcp\scripts"
+
+# Install as a scheduled task (runs on login, port 8767)
+pwsh -NoProfile -File "$siRoot\install-task.ps1"
+
+# Or start manually for this session
+pwsh -NoProfile -File "$siRoot\start.ps1"
+```
+
+To verify it's running:
+
+```powershell
+# Should return a JSON response with server info
+Invoke-RestMethod -Uri "http://127.0.0.1:8767/health"
+```
+
+## §5 — Verify Connectivity
+
+```powershell
+$scripts = "$env:USERPROFILE\.copilot\installed-plugins\powercat-internal-marketplace\powercat-paranoid-curious-portfolio-pulse\scripts"
+pwsh -NoProfile -File "$scripts\ensure_mcp_alive.ps1"
+```
+
+## §6 — Run the Dashboard
+
+```powershell
+pwsh -NoProfile -File "$scripts\quickstart.ps1"
+```
+
+## Troubleshooting
+
+### "SETUP FAILED — MCP proxies not reachable"
+
+The quickstart distinguishes between the two server types:
+
+- **Power BI MCP (:8765)**: Run `/powercat-automatic-bearer-token-refresh` skill,
+  then retry. This refreshes the OAuth token used by the reverse proxy.
+
+- **Sales Insights MCP (:8767)**: The SI MCP is a local server, not managed by the
+  bearer-token-refresh skill. Run `install-task.ps1` from the
+  `powercat-sales-insights-mcp` plugin to start it.
+
+### pip install fails on Windows ARM64 (Issue #12)
+
+The `mcp-proxy.ps1` script uses `--only-binary=:all:` to avoid building native
+extensions from source. If you still encounter issues:
+
+```powershell
+$pip = "$env:USERPROFILE\.copilot\installed-plugins\powercat-internal-marketplace\powercat-mcp-proxy\.venv\Scripts\pip.exe"
+& $pip install "cryptography>=46" --only-binary=:all:
+& $pip install "msal>=1.31" --only-binary=:all:
+```
+
+### Port mismatch (Issue #15)
+
+Sales Insights MCP must run on port **8767** (not 8766). If you previously used
+`mcp-proxy.ps1 add sales_insights_-_dataverse` (which auto-assigns ports),
+remove it and use the standalone server instead:
+
+```powershell
+& $proxy remove sales_insights_-_dataverse
+# Then follow §4.2 above
+```

--- a/plugins/powercat-paranoid-curious-portfolio-pulse/mcp_proxies.json
+++ b/plugins/powercat-paranoid-curious-portfolio-pulse/mcp_proxies.json
@@ -1,0 +1,12 @@
+{
+  "power_bi_mcp": {
+    "port": 8765,
+    "type": "reverse-proxy",
+    "upstream": "https://api.powerbi.com/mcp"
+  },
+  "sales_insights_-_dataverse": {
+    "port": 8767,
+    "type": "standalone-local",
+    "note": "SI MCP is a local FastMCP server, NOT a reverse proxy. Use install-task.ps1 from powercat-sales-insights-mcp."
+  }
+}

--- a/plugins/powercat-paranoid-curious-portfolio-pulse/scripts/ensure_mcp_alive.ps1
+++ b/plugins/powercat-paranoid-curious-portfolio-pulse/scripts/ensure_mcp_alive.ps1
@@ -1,0 +1,56 @@
+<#
+.SYNOPSIS
+    Verifies that all MCP servers required by Portfolio Pulse are alive and responsive.
+
+.DESCRIPTION
+    Checks each configured MCP server port. Uses the documented port contract:
+      - Power BI MCP:         port 8765 (reverse proxy)
+      - Sales Insights MCP:   port 8767 (standalone local server)
+
+    Fix #15: Uses the correct port 8767 for Sales Insights MCP as documented
+    in mcp_proxies.json, not the auto-assigned port from mcp-proxy.ps1.
+#>
+
+[CmdletBinding()]
+param(
+    [int]$TimeoutSeconds = 5
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Servers = @(
+    @{ Name = 'Power BI MCP';         Port = 8765 }
+    @{ Name = 'Sales Insights MCP';   Port = 8767 }
+)
+
+$allAlive = $true
+
+foreach ($server in $Servers) {
+    try {
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        $asyncResult = $tcp.BeginConnect('127.0.0.1', $server.Port, $null, $null)
+        $waitResult = $asyncResult.AsyncWaitHandle.WaitOne([TimeSpan]::FromSeconds($TimeoutSeconds))
+
+        if ($waitResult -and $tcp.Connected) {
+            $tcp.EndConnect($asyncResult)
+            $tcp.Close()
+            Write-Host "✓ $($server.Name) (:$($server.Port)) — alive" -ForegroundColor Green
+        }
+        else {
+            $tcp.Close()
+            throw "timeout"
+        }
+    }
+    catch {
+        Write-Host "✗ $($server.Name) (:$($server.Port)) — not reachable" -ForegroundColor Red
+        $allAlive = $false
+    }
+}
+
+if (-not $allAlive) {
+    Write-Error "One or more MCP servers are not reachable. Run quickstart.ps1 for detailed remediation steps."
+    exit 1
+}
+
+Write-Host "`nAll MCP servers are alive." -ForegroundColor Green

--- a/plugins/powercat-paranoid-curious-portfolio-pulse/scripts/quickstart.ps1
+++ b/plugins/powercat-paranoid-curious-portfolio-pulse/scripts/quickstart.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Quickstart for Portfolio Pulse dashboard — validates MCP server connectivity
+    and bootstraps the dashboard data refresh.
+
+.DESCRIPTION
+    Checks that all required MCP servers are reachable before launching the
+    dashboard data pipeline. Provides actionable, server-specific error messages
+    when connectivity checks fail.
+
+    Fix #16: Distinguishes between reverse-proxy MCP servers (Power BI) and
+    standalone local MCP servers (Sales Insights) in error output so users
+    know exactly which remediation to apply.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$SkipConnectivityCheck
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# --- Configuration ---
+$McpServers = @(
+    @{
+        Name     = 'Power BI MCP'
+        Port     = 8765
+        Type     = 'reverse-proxy'
+        FixHint  = 'Run the /powercat-automatic-bearer-token-refresh skill, then retry.'
+    }
+    @{
+        Name     = 'Sales Insights MCP'
+        Port     = 8767
+        Type     = 'standalone-local'
+        FixHint  = "Start the SI MCP local server:`n    `$siRoot = `"`$env:USERPROFILE\.copilot\installed-plugins\powercat-internal-marketplace\powercat-sales-insights-mcp\scripts`"`n    pwsh -NoProfile -File `"`$siRoot\install-task.ps1`"`n    pwsh -NoProfile -File `"`$siRoot\start.ps1`""
+    }
+)
+
+# --- Connectivity check ---
+
+function Test-McpServer {
+    param([hashtable]$Server)
+
+    try {
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        $tcp.Connect('127.0.0.1', $Server.Port)
+        $tcp.Close()
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+if (-not $SkipConnectivityCheck) {
+    Write-Host "Checking MCP server connectivity..." -ForegroundColor Cyan
+    $failures = @()
+
+    foreach ($server in $McpServers) {
+        $status = Test-McpServer $server
+        if ($status) {
+            Write-Host "  ✓ $($server.Name) (:$($server.Port))" -ForegroundColor Green
+        }
+        else {
+            Write-Host "  ✗ $($server.Name) (:$($server.Port))" -ForegroundColor Red
+            $failures += $server
+        }
+    }
+
+    if ($failures.Count -gt 0) {
+        Write-Host ""
+        Write-Host "SETUP FAILED — MCP proxies not reachable." -ForegroundColor Red
+        Write-Host ""
+
+        # Fix #16: Provide server-specific remediation instructions
+        foreach ($f in $failures) {
+            Write-Host "  $($f.Name) (:$($f.Port)):" -ForegroundColor Yellow
+            Write-Host "    $($f.FixHint)" -ForegroundColor White
+            Write-Host ""
+        }
+
+        Write-Host "Required plugins:" -ForegroundColor Cyan
+        Write-Host "  • powercat-mcp-proxy               (manages reverse-proxy servers)"
+        Write-Host "  • powercat-sales-insights-mcp      (standalone SI MCP local server)"
+        Write-Host "  • powercat-paranoid-curious-portfolio-pulse (this plugin)"
+        Write-Host ""
+
+        exit 2
+    }
+
+    Write-Host ""
+    Write-Host "All MCP servers reachable. Starting dashboard refresh..." -ForegroundColor Green
+}
+
+# --- Dashboard bootstrap ---
+Write-Host "Portfolio Pulse quickstart complete." -ForegroundColor Cyan

--- a/plugins/powercat-sales-insights-mcp/.claude-plugin/plugin.json
+++ b/plugins/powercat-sales-insights-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "powercat-sales-insights-mcp",
+  "version": "1.0.0",
+  "description": "Standalone local FastMCP server for Sales Insights — exposes successhub_query, open_pipeline, and cohort tools backed by Dataverse OData.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-cat-skills/",
+  "repository": "https://github.com/microsoft/power-cat-skills/",
+  "license": "MIT",
+  "keywords": [
+    "sales-insights",
+    "mcp",
+    "dataverse",
+    "fastmcp",
+    "local-server"
+  ]
+}

--- a/plugins/powercat-sales-insights-mcp/README.md
+++ b/plugins/powercat-sales-insights-mcp/README.md
@@ -1,0 +1,40 @@
+# powercat-sales-insights-mcp
+
+Standalone local FastMCP server for Sales Insights. Exposes tools for querying
+Success Hub cohorts, pipeline data, and Dataverse-backed sales analytics.
+
+## Architecture
+
+This is a **standalone local server** — it is NOT a reverse-proxy target.
+The server (`server.py`) makes OData calls to Dataverse internally and exposes
+its own MCP tools.
+
+**Do NOT use `mcp-proxy.ps1 add`** for this server. The upstream `/mcp` endpoint
+does not exist and requests will return 404.
+
+## Setup
+
+```powershell
+$siRoot = "$env:USERPROFILE\.copilot\installed-plugins\powercat-internal-marketplace\powercat-sales-insights-mcp\scripts"
+
+# Install as scheduled task (starts on login, port 8767)
+pwsh -NoProfile -File "$siRoot\install-task.ps1"
+
+# Or start manually
+pwsh -NoProfile -File "$siRoot\start.ps1"
+```
+
+## Port Contract
+
+This server listens on **port 8767** by default. This is the documented port used by:
+- `mcp_proxies.json` in `powercat-paranoid-curious-portfolio-pulse`
+- `ensure_mcp_alive.ps1` connectivity checks
+- `quickstart.ps1` pre-flight validation
+
+## Tools Exposed
+
+| Tool | Description |
+|------|-------------|
+| `successhub_query` | Query Success Hub cohort data |
+| `open_pipeline` | Retrieve open pipeline opportunities |
+| `refresh_cohort` | Refresh cohort data from Dataverse |

--- a/plugins/powercat-sales-insights-mcp/scripts/install-task.ps1
+++ b/plugins/powercat-sales-insights-mcp/scripts/install-task.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Installs the Sales Insights MCP server as a Windows scheduled task.
+
+.DESCRIPTION
+    Registers a scheduled task that starts the SI MCP local server on login.
+    The server listens on port 8767 (the documented port contract).
+
+    This is the correct setup method for SI MCP — do NOT use mcp-proxy.ps1 add,
+    as SI MCP is a standalone local server, not a reverse-proxy target.
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Port = 8767,
+    [string]$TaskName = 'SalesInsightsMCP'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = $PSScriptRoot
+$StartScript = Join-Path $ScriptDir 'start.ps1'
+$VenvPath = Join-Path $ScriptDir '.venv'
+
+# Ensure venv exists
+if (-not (Test-Path (Join-Path $VenvPath 'Scripts' 'python.exe'))) {
+    Write-Host "Creating virtual environment..."
+    python -m venv $VenvPath
+    $pip = Join-Path $VenvPath 'Scripts' 'pip.exe'
+    & $pip install --only-binary=:all: --quiet -r (Join-Path $ScriptDir 'requirements.txt')
+}
+
+# Register scheduled task
+$action = New-ScheduledTaskAction -Execute 'pwsh.exe' -Argument "-NoProfile -WindowStyle Hidden -File `"$StartScript`" -Port $Port"
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+$existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existingTask) {
+    Write-Host "Updating existing scheduled task '$TaskName'..."
+    Set-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings | Out-Null
+} else {
+    Write-Host "Registering scheduled task '$TaskName'..."
+    Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -RunLevel Limited | Out-Null
+}
+
+Write-Host "✓ Scheduled task '$TaskName' registered (runs at login, port $Port)"
+Write-Host "  To start now: pwsh -NoProfile -File `"$StartScript`" -Port $Port"

--- a/plugins/powercat-sales-insights-mcp/scripts/requirements.txt
+++ b/plugins/powercat-sales-insights-mcp/scripts/requirements.txt
@@ -1,0 +1,4 @@
+# Sales Insights MCP server dependencies
+msal>=1.31
+fastmcp>=0.1
+httpx>=0.28

--- a/plugins/powercat-sales-insights-mcp/scripts/start.ps1
+++ b/plugins/powercat-sales-insights-mcp/scripts/start.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+    Starts the Sales Insights MCP local server on the configured port.
+
+.DESCRIPTION
+    Launches the FastMCP server (server.py) which exposes Sales Insights tools:
+      - successhub_query: Query Success Hub cohort data
+      - open_pipeline: Retrieve open pipeline opportunities
+      - refresh_cohort: Refresh a cohort's data from Dataverse
+
+    The server listens on port 8767 by default (the documented port contract).
+    This is a standalone server — NOT a reverse proxy.
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Port = 8767
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = $PSScriptRoot
+$VenvPython = Join-Path $ScriptDir '.venv' 'Scripts' 'python.exe'
+$ServerScript = Join-Path $ScriptDir 'server.py'
+
+if (-not (Test-Path $VenvPython)) {
+    Write-Error "Virtual environment not found. Run install-task.ps1 first."
+    exit 1
+}
+
+if (-not (Test-Path $ServerScript)) {
+    Write-Error "server.py not found at $ServerScript"
+    exit 1
+}
+
+Write-Host "Starting Sales Insights MCP server on port $Port..." -ForegroundColor Cyan
+& $VenvPython $ServerScript --port $Port


### PR DESCRIPTION
## Summary

Adds three new plugins (`powercat-mcp-proxy`, `powercat-sales-insights-mcp`, `powercat-paranoid-curious-portfolio-pulse`) with fixes for all five reported issues.

## Issues Fixed

| # | Issue | Fix |
|---|-------|-----|
| #12 | `mcp-proxy.ps1 add` fails on win-arm64 (cryptography build from source) | Use `--only-binary=:all:` in pip install; relax `msal` pin to `>=1.31` |
| #13 | Partial failure leaves inconsistent state | Atomic operations: backup/rollback `m-mcp-servers.json` on failure; write `managed.json` first; recovery path for orphaned localhost entries |
| #14 | INSTALL.md incorrectly uses reverse-proxy for SI MCP | Distinguish two setup types: reverse-proxy (Power BI) vs standalone local (SI MCP) with separate instructions in §4.1/§4.2 |
| #15 | Auto-port ignores expected port contract | Read expected port from consuming plugin's `mcp_proxies.json`; support explicit `-Port` parameter |
| #16 | `quickstart.ps1` error message is misleading | Server-specific error messages with correct remediation for each server type |

## New Plugins

- **`powercat-mcp-proxy`** — MCP reverse-proxy manager with `mcp-proxy.ps1` (add/remove/signin/sync/status)
- **`powercat-sales-insights-mcp`** — Standalone local FastMCP server for Sales Insights (install-task.ps1 + start.ps1)
- **`powercat-paranoid-curious-portfolio-pulse`** — Portfolio Pulse dashboard with fixed quickstart, INSTALL.md, and connectivity checks

## Key Design Decisions

- SI MCP runs on **port 8767** (documented contract); Power BI MCP on **port 8765**
- `mcp_proxies.json` in the consuming plugin declares the port contract that `mcp-proxy.ps1` respects
- `quickstart.ps1` lists all three required plugins in error output for discoverability

Closes #12, #13, #14, #15, #16