### PR TITLE
Add powercat-admin-digest plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,6 +106,22 @@
         "eval", "testing", "code apps", "generative pages",
         "security", "power platform", "power apps", "microsoft"
       ]
+    },
+    {
+      "name": "powercat-admin-digest",
+      "description": "Power Platform admin digest — Message Center notices, Service Health incidents, Known Issues, and deprecations that can affect production operations, with shareability tiering so customer-facing summaries never leak NDA content.",
+      "source": "./plugins/powercat-admin-digest",
+      "skills": [
+        "./plugins/powercat-admin-digest/skills/powercat-admin-digest"
+      ],
+      "version": "1.0.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "admin", "message center", "service health",
+        "deprecations", "power platform", "powercat", "microsoft"
+      ]
     }
   ]
 }

--- a/plugins/powercat-admin-digest/.claude-plugin/plugin.json
+++ b/plugins/powercat-admin-digest/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "powercat-admin-digest",
+  "version": "1.0.0",
+  "description": "Power Platform admin digest — surfaces Message Center notices, Service Health incidents, Known Issues, and deprecations that can affect production operations, with shareability tiering so customer-facing summaries never leak NDA content.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/power-cat-skills/",
+  "repository": "https://github.com/microsoft/power-cat-skills/",
+  "license": "MIT",
+  "keywords": [
+    "power-platform",
+    "admin",
+    "message-center",
+    "service-health",
+    "deprecations",
+    "powercat"
+  ]
+}

--- a/plugins/powercat-admin-digest/AGENTS.md
+++ b/plugins/powercat-admin-digest/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — Admin Digest Plugin
+
+This file provides guidance to AI Agents when working with the **powercat-admin-digest** plugin.
+
+## What This Plugin Is
+
+A plugin for Power Platform admins and partner SAs that produces a **production-impact digest** by synthesizing Message Center notices, Service Health incidents, Known Issues, and deprecations from the user's M365 mailbox and public Microsoft sources. Default output is **customer-shareable** (Tier 1 + Tier 2 only); Tier 3 (NDA / Microsoft-internal) content is stripped unless the user explicitly asks for the `internal` variant.
+
+Skills delegate `.docx` / `.pptx` export to the matching first-party skills (`docx` / `pptx`).
+
+## Local Development
+
+Test this plugin locally:
+
+```bash
+claude --plugin-dir /path/to/plugins/powercat-admin-digest
+```
+
+## Architecture
+
+```
+.claude-plugin/plugin.json     ← Plugin metadata (name, version, keywords)
+AGENTS.md                      ← Plugin guidance for AI agents (this file)
+CLAUDE.md                      ← Symlink → AGENTS.md
+README.md
+skills/
+  powercat-admin-digest/
+    powercat-admin-digest.md   ← Production-impact digest with shareability tiering
+```
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/powercat-admin-digest` | Power Platform production-impact digest (Message Center, Service Health, KIs, deprecations) with Public / Tenant-restricted / Microsoft-internal tiering |
+
+### `/powercat-admin-digest` — Power Platform Admin Digest
+
+Pulls findings from the user's mailbox and public Microsoft sources, filters to production-impact items, tags each by shareability tier, and renders three concise tables.
+
+**Triggers:** `admin digest`, `power platform digest`, `what's affecting production`, `production-impact summary`, `message center summary`, `service health summary`
+
+**What it does:**
+
+1. Searches the mailbox (default 30-day lookback, configurable) using `m365_search_emails` for Message Center notices, Service Health threads, deprecations, and Known Issues across Power Apps, Power Automate, Dataverse, Copilot Studio, Power Pages, and Customer Insights – Journeys.
+2. Reads top hits with `m365_get_email` (text body); batches up to 4–6 in parallel and backs off serially on Graph 429 throttling.
+3. Filters to production-impact items (drops feature announcements, marketing recaps, internal logistics).
+4. Tags each item Tier 1 / Tier 2 / Tier 3.
+5. Renders tables-only chat output: *Active changes — review and act*, *Active known issues*, *Recently resolved (Service Health)*.
+6. Names the top 1–2 items to action today and offers `.docx` / `.pptx` export.
+
+**Variants:**
+
+- `internal` — adds Tier 3 section, clearly labelled "Do not forward externally"
+- `public-only` — Tier 1 rows only
+- `.docx` / `.pptx` — re-renders tables via the `docx` / `pptx` skill
+
+**Safety guardrails:**
+
+- Never includes ICM / LSI / internal-portal links, customer escalation TrackingIDs, or internal feature-control flags in default (customer-shareable) output.
+- Outbound sends (email / Teams) require explicit recipient + content preview before transmission.
+
+**Requires:**
+
+- Host capability to call `m365_search_emails` and `m365_get_email` (e.g. Clawpilot's M365 toolset).
+- Optional `web_fetch` for enriching deprecation entries from Microsoft Learn.
+
+## Prerequisites
+
+- Microsoft 365 mailbox access via the host's M365 tooling.
+
+## Why this plugin exists
+
+Tenant admins routinely need to brief customers on "what changed and what might break" without leaking NDA content from internal escalation threads. This skill does that filtering automatically, so the default chat output is forwardable as-is.

--- a/plugins/powercat-admin-digest/CLAUDE.md
+++ b/plugins/powercat-admin-digest/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/plugins/powercat-admin-digest/README.md
+++ b/plugins/powercat-admin-digest/README.md
@@ -1,0 +1,72 @@
+# Power CAT Admin Digest Plugin
+
+This plugin produces a **Power Platform production-impact digest** for tenant admins and partner SAs. It synthesizes Message Center notices, Service Health incidents, Known Issues, and deprecation announcements from the user's M365 mailbox and public Microsoft sources, then filters and **tiers** the findings so the default chat output is safe to forward to a customer.
+
+> **Preview:** This plugin is in [preview](https://www.microsoft.com/en-us/business-applications/legal/supp-powerplatform-preview/). These features are available before official release for customers to provide feedback.
+
+## Prerequisites
+
+- Microsoft 365 mailbox access (the host environment must expose `m365_search_emails` / `m365_get_email` tools, e.g. Clawpilot)
+- Optional: web fetch capability for enriching deprecation entries from [Microsoft Learn](https://learn.microsoft.com/power-platform/important-changes-coming)
+
+## Installation
+
+### From the marketplace
+
+```bash
+/plugin marketplace add microsoft/power-cat-skills
+/plugin install powercat-admin-digest@power-cat-skills
+```
+
+### From a local clone
+
+```bash
+claude --plugin-dir /path/to/power-cat-skills/plugins/powercat-admin-digest
+```
+
+## Skills
+
+### `/powercat-admin-digest` — Power Platform Admin Digest
+
+USE WHEN the user asks "what's affecting Power Platform production right now?", wants an admin digest, or asks for a summary of Message Center / Service Health for Power Platform.
+
+**Usage:** Invoke directly with `/powercat-admin-digest`, or use any of the phrases below to trigger the skill automatically:
+
+- `Give me a power platform admin digest`
+- `What's affecting production?`
+- `Summarize Message Center for Power Platform`
+- `Production-impact summary`
+
+**What it does:**
+
+1. Searches the user's mailbox (default 30-day lookback) for Message Center notices, Service Health threads, deprecation announcements, and Known Issues across Power Apps, Power Automate, Dataverse, Copilot Studio, Power Pages, and Customer Insights – Journeys.
+2. Filters to items that genuinely affect production operations (drops feature announcements, marketing recaps, internal logistics).
+3. Tags every finding by shareability tier:
+   - **Tier 1 — Public** (Microsoft Learn, public KI portal, `aka.ms` links)
+   - **Tier 2 — Tenant-restricted** (Message Center, Service Health)
+   - **Tier 3 — Microsoft-internal / NDA** (always stripped from the default output)
+4. Renders three concise tables: *Active changes*, *Active known issues*, *Recently resolved*.
+5. Highlights the top 1–2 items to action today and offers `.docx` / `.pptx` export.
+
+**Variants:**
+
+- `internal` — adds a clearly-labelled Tier 3 section (do-not-forward).
+- `public-only` — emits Tier 1 rows only, replacing MC#### with the public Learn equivalent where available.
+- `.docx` / `.pptx` — re-renders the tables via the matching skill.
+
+**Privacy guardrails baked in:**
+
+- ICM / LSI / internal triage references never appear in customer-shareable output.
+- Customer escalation TrackingIDs, named engagement details, and internal feature-control flags are filtered.
+- Outbound sends (email / Teams) require explicit recipient + content preview before transmission.
+
+## Support
+
+If you face issues with:
+
+- **Using this skill:** Report your issue here: [https://github.com/microsoft/power-cat-skills/issues](https://github.com/microsoft/power-cat-skills/issues). (Microsoft Support won't help with issues related to this plugin, but they will help with related, underlying platform and feature issues.)
+- **The core features in Microsoft Power Platform:** Use your standard channel to contact Microsoft Support.
+
+## License
+
+See the [LICENSE](../../LICENSE) file for license information.

--- a/plugins/powercat-admin-digest/skills/powercat-admin-digest/powercat-admin-digest.md
+++ b/plugins/powercat-admin-digest/skills/powercat-admin-digest/powercat-admin-digest.md
@@ -1,0 +1,107 @@
+---
+name: "powercat-admin-digest"
+description: "Produce a Power Platform admin digest of items that can affect production operations — Message Center notices, Service Health incidents, Known Issues, and deprecations — synthesized from the user's mailbox and public Microsoft sources. Categorizes findings into shareability tiers (Public / Tenant-restricted / Microsoft-internal) and outputs a concise customer-shareable summary by default. Triggers: 'admin digest', 'power platform digest', 'what's affecting production', 'production-impact summary"
+---
+
+# powercat-admin-digest
+
+Produce a **Power Platform production-impact digest** for an admin or partner audience. Pulls from the user's M365 mailbox (Message Center notices, partner threads, support escalations, MVP/NDA discussions) and from public Microsoft sources, then filters and categorizes by shareability tier.
+
+## When to invoke
+
+User asks things like:
+- "What's affecting Power Platform production right now?"
+- "Give me an admin digest"
+- "Summarize Message Center / Service Health for Power Platform"
+- "What outages or upcoming changes should I know about?"
+
+## Inputs (ask only if missing)
+
+- **Lookback window** — default: last 30 days. Accept "last 7 days", "last quarter", explicit dates.
+- **Audience** — default: customer-shareable (Tier 1 + Tier 2). Other options: "internal" (all tiers, including Tier 3) or "public-only" (Tier 1 only).
+- **Scope** — default: all Power Platform (Power Apps, Power Automate, Dataverse, Copilot Studio, Power Pages, CI-J). Accept narrower scope if requested.
+
+Do not ask about format up front. Default to a concise chat response (tables only). Offer .docx / .pptx export at the end.
+
+## Gathering steps (in parallel where possible)
+
+1. **Mailbox** — call `m365_search_emails` with `startDate` = lookback start, multiple queries in parallel:
+   - `"Message Center Power Platform"`
+   - `"service health Power Apps Power Automate Dataverse incident"`
+   - `"deprecation Power Platform breaking change"`
+   - `"MC1" OR "MC2"` (catches MC#### references)
+   - `"known issue" Power Platform`
+2. **Read top hits** with `m365_get_email` using `bodyContentType: "text"`. Batch up to 4–6 in parallel; if Graph throttles (429), back off and retry sequentially.
+3. **Extract** for each item: title, MC# / KI# / ICM#, effective date, scope, customer impact, action required, workaround if any, and the *source* (which mailbox thread or public URL).
+4. (Optional, only if user asks for "latest public" view) fetch the Microsoft Learn deprecations page via `web_fetch`: `https://learn.microsoft.com/power-platform/important-changes-coming`.
+
+## Filtering — production-impact only
+
+KEEP an item if it affects production operations in any of these ways:
+- Changes a default that ran for years (retention, storage tiering, IPs, auth)
+- Retires or deprecates a feature with a hard date
+- Active regression / known issue currently hitting customers
+- Resolved incident that may still require follow-up (e.g., RCA, data integrity check)
+
+DROP items that are:
+- Pure feature announcements with no breaking change
+- Marketing / event recaps
+- Internal team logistics
+- Already past their cutover with no remediation needed
+
+## Tier classification (CRITICAL — drives shareability)
+
+Apply this tagging to every kept item:
+
+| Tier | Definition | Examples |
+|------|-----------|----------|
+| **Tier 1 — Public** | On the open web. Anyone can read. | `learn.microsoft.com` pages, public KI portal entries (`admin.powerplatform.microsoft.com/support/knownissues/<id>`), Release Planner, `aka.ms` links, public roadmap |
+| **Tier 2 — Tenant-restricted** | Visible to tenant admins via Admin Center, not on the open web. | Message Center notices (MC####), Service Health incidents, PPAC notifications |
+| **Tier 3 — Microsoft-internal / NDA** | Only Microsoft employees or NDA partners. **Never put in customer-facing output.** | ICM #, LSI #, Iridias links, internal v-team emails, MVP NDA threads, internal Kusto queries, FCB flag mitigations, internal customer escalation TrackingIDs, named customer engagement details |
+
+**Default output is Tier 1 + Tier 2 only.** Tier 3 items are summarized internally for the user's own awareness but MUST NOT appear in shareable output. If user asks for "internal" audience, include Tier 3 in a separate clearly-labeled section.
+
+## Output format
+
+Default response = **tables only**, three sections, concise:
+
+### Active changes — review and act
+| # | Change | What it means | Reference |
+
+### Active known issues
+| # | Issue | Status | Workaround |
+
+### Recently resolved (Service Health)
+| # | Incident | When |
+
+Rules for the tables:
+- Reference column: MC#### · public `aka.ms/...` or `learn.microsoft.com/...` link (no Iridias, no ICM).
+- Workaround column: only customer-applicable steps. Don't paste FCB flags or internal triage steps.
+- Keep rows short — one line each where possible. Bold the change name.
+- If a section is empty, omit it entirely.
+
+After the tables, in one sentence, name the **top 1–2 items to action today** and offer `.docx` / `.pptx` export.
+
+## Privacy guardrails
+
+- Never include named customer accounts, TrackingIDs, or escalation specifics in shareable output.
+- Never include ICM / LSI / Iridias / PR numbers in shareable output.
+- Never include FCB flag commands in shareable output.
+- If the session contains MIP-classified content, warn the user before producing any exported file.
+- If the user asks you to *send* the digest to a third party (email, Teams), preview the exact content and recipient list first and require explicit confirmation, per standard outbound rules.
+
+## Variants the user may ask for
+
+- **"public-only"** → emit Tier 1 rows only; replace MC#### references with their public Learn equivalents where available.
+- **"internal"** → add a fourth section "Microsoft-internal context" with Tier 3 items, clearly marked "Do not forward externally."
+- **".docx" / ".pptx" export** → invoke the matching skill (`docx` / `pptx`) and re-render the tables there. Strip any Tier 3 content even if the user has it; ask before including Tier 3.
+
+## Worked example (shape only — do not copy verbatim)
+
+```
+## Active changes — review and act
+| # | Change | What it means | Reference |
+| 1 | **Backup retention 28 → 7 days** (May 11, 2026) | Default restore window shrunk... | MC1298714 · aka.ms/14441 |
+...
+```
+


### PR DESCRIPTION
## Summary

Adds **powercat-admin-digest** — a Power CAT skill that produces a Power Platform production-impact digest by synthesizing Message Center notices, Service Health incidents, Known Issues, and deprecation announcements from the user's M365 mailbox and public Microsoft sources.

The skill's distinguishing feature is **shareability tiering**: every finding is tagged Tier 1 (Public), Tier 2 (Tenant-restricted), or Tier 3 (Microsoft-internal / NDA), and the default chat output strips Tier 3 so the result is safe to forward to a customer without manual review.

## What this plugin adds

- `plugin.json`, `README.md`, `AGENTS.md`, `CLAUDE.md` at `plugins/powercat-admin-digest/`
- One skill: `skills/powercat-admin-digest/powercat-admin-digest.md`
- New entry in `.claude-plugin/marketplace.json`

## Skill triggers

`admin digest` · `power platform digest` · `what''s affecting production` · `production-impact summary` · `message center summary` · `service health summary`

## Output

Three concise tables — *Active changes — review and act*, *Active known issues*, *Recently resolved (Service Health)* — followed by a one-sentence "top items to action today" and an offer to export to `.docx` / `.pptx`.

## Variants

- `internal` — adds a clearly labelled Tier 3 section ("Do not forward externally")
- `public-only` — Tier 1 rows only
- `.docx` / `.pptx` — re-renders the tables via the matching `docx` / `pptx` skill

## Public-readiness checks

Acknowledged before opening this PR:

- **External references**: 5 unique URLs, all return **200 unauthenticated** (Learn, microsoft.com, github.com/microsoft/power-cat-skills)
- **Local file paths**: none
- **Emails / PII**: none
- **Secrets**: none
- **Customer / people names**: none
- **Internal domains**: the word "Iridias" appears 3× inside the skill''s privacy guardrail prose ("Never include … Iridias …") — it documents what the skill must *strip from output*, not a URL or asset reference; informational only

## Privacy guardrails baked into the skill

- ICM / LSI / internal-portal links, customer escalation TrackingIDs, and internal feature-control flags never appear in the default (customer-shareable) output.
- Outbound sends (email / Teams) require explicit recipient + content preview before transmission.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
