### PR TITLE
Add powercat-overflow plugin scaffold (plugin.json, AGENTS.md, CLAUDE.md, SKILL.md)

### DIFF
--- a/plugins/powercat-overflow/.claude-plugin/plugin.json
+++ b/plugins/powercat-overflow/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "powercat-overflow",
+  "version": "0.2.0",
+  "description": "Reviews every Power Automate cloud flow inside a Power Platform solution (.zip) against Microsoft's coding guidelines and produces a [SolutionName].findings.json next to the uploaded solution, then opens the hosted PowerCAT-Overflow viewer at https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html and uploads both files so the user can explore the results.",
+  "author": {
+    "name": "Power CAT",
+    "url": "https://aka.ms/powercat"
+  },
+  "homepage": "https://github.com/microsoft/power-cat-skills/",
+  "repository": "https://github.com/microsoft/power-cat-skills/",
+  "license": "MIT",
+  "keywords": [
+    "power-platform",
+    "power-automate",
+    "powercat",
+    "powercat-overflow",
+    "cloud-flow",
+    "logic-apps",
+    "solution-review",
+    "code-review"
+  ]
+}

--- a/plugins/powercat-overflow/AGENTS.md
+++ b/plugins/powercat-overflow/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md — PowerCAT-Overflow Plugin
+
+This file provides guidance to AI Agents when working with the **powercat-overflow** plugin.
+
+## What This Plugin Is
+
+A plugin for Power Platform makers, ALM owners, and CoE reviewers that audits **every Power Automate cloud flow inside a Power Platform solution `.zip`** against Microsoft's published coding guidelines. The skill unpacks the solution, walks each flow, classifies findings by impact (low / medium / high), writes a single `[SolutionName].findings.json` next to the uploaded ZIP, and opens the **hosted PowerCAT-Overflow viewer** (<https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html>) with both the solution and findings files pre-loaded so the user can explore the results visually.
+
+All citations in findings must come from the authoritative source list at `Common/PowerCAT OverFlow/sources.md` in this repo. Findings that cannot anchor to that list are not emitted.
+
+## Local Development
+
+Test this plugin locally:
+
+```bash
+claude --plugin-dir /path/to/plugins/powercat-overflow
+```
+
+## Architecture
+
+```
+.claude-plugin/plugin.json                     ← Plugin metadata (name, version, keywords)
+AGENTS.md                                      ← Plugin guidance for AI agents (this file)
+CLAUDE.md                                      ← Pointer → AGENTS.md
+README.md                                      ← User-facing plugin docs
+skills/
+  powercat-overflow/
+    SKILL.md                                   ← Solution-level cloud-flow review skill
+```
+
+External assets consumed at run time (not bundled — fetched live from this repo):
+
+- `Common/PowerCAT OverFlow/sources.md` — authoritative citation list (hard-required)
+- `Common/PowerCAT OverFlow/solution.findings.schema.json` — output schema (validation)
+- `Common/PowerCAT OverFlow/StressTest100Flows_1_0_0_0.zip` — sample solution used in the README "Explore it now" walkthrough
+- `https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html` — hosted viewer (GitHub Pages)
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/powercat-overflow` | Reviews every Power Automate cloud flow inside a Power Platform solution `.zip`, writes a single solution-level findings JSON, then opens the hosted viewer with both files loaded. |
+
+### `/powercat-overflow` — Solution-level Cloud-Flow Review
+
+**Triggers:** `powercat overflow`, `overflow my solution`, `review my solution`, `evaluate flows in this solution`, `audit Power Automate solution`, `check this solution against guidelines`
+
+**What it does:**
+
+1. Fetches the canonical source list (`Common/PowerCAT OverFlow/sources.md`) and caches it for the run. Hard-fails if unreachable — no citations means no findings.
+2. Locates the user's solution `.zip` (preferring tagged files; otherwise prompts via `m_ask_user`).
+3. Unpacks the ZIP, reads `solution.xml` (display name, unique name, version) and enumerates every `Workflows/*.json` file.
+4. For each flow, walks every action recursively (`actions`, `else.actions`, `cases.*.actions`, `default.actions`) and emits findings classified as **low**, **medium**, or **high** across: Complexity, Maintainability, Security, Performance, Reliability, Observability, Testability, and Naming.
+5. Validates the aggregated output against `solution.findings.schema.json` (also fetched live), then writes `[SolutionName].findings.json` next to the input ZIP.
+6. Opens the hosted viewer via Playwright and uploads both the `.zip` and the `.findings.json` so the user can browse findings overlaid on the visual flow diagram.
+
+**Safety guardrails:**
+
+- The skill **never** fabricates citation URLs — every `source` field must match an entry from the Step 0 source list.
+- The skill writes exactly one output file per run (`[SolutionName].findings.json`) and never modifies the input solution.
+- Hosted-viewer interaction is read-only — Playwright uploads files but does not submit, share, or persist anything server-side.
+
+**Requires:**
+
+- Host capability to run Playwright (the skill drives the hosted viewer in a real browser).
+- `web_fetch` for retrieving the source list and schema from this repo.
+- File-system access to unpack the ZIP into a temp working directory.
+
+## Prerequisites
+
+- A Power Platform solution `.zip` containing a `Workflows/` folder with one or more cloud flow JSON files.
+- Network access to `microsoft.github.io` and `raw.githubusercontent.com` for the source list, schema, and hosted viewer.
+
+## Why this plugin exists
+
+ALM-owned Power Automate solutions accumulate technical debt fast: hardcoded URLs, magic numbers, missing `secureData` flags, deep nested Conditions, sibling Scopes that should be child flows, duplicate `Copyof-…` flows shipped alongside originals. Reviewers had no fast way to scan an entire solution end-to-end without opening each flow by hand in the maker portal. `powercat-overflow` automates that scan, anchors every finding to Microsoft's published guidance, and renders the results on top of the actual flow diagram so the reviewer can act in minutes instead of hours.

--- a/plugins/powercat-overflow/CLAUDE.md
+++ b/plugins/powercat-overflow/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/plugins/powercat-overflow/README.md
+++ b/plugins/powercat-overflow/README.md
@@ -2,7 +2,7 @@
 <img width="2036" height="1080" alt="image" src="https://github.com/user-attachments/assets/a0ef4ffd-2505-465b-94a7-38e1b9f93812" />
 <img width="2036" height="1080" alt="image" src="https://github.com/user-attachments/assets/b19bf17e-a022-43f5-b192-575601b1caca" />
 
-Reviews every Power Automate cloud flow inside a Power Platform solution (`.zip`) against Microsoft''s coding guidelines and produces a `[SolutionName].findings.json` next to the uploaded solution. Then opens the hosted PowerCAT-Overflow viewer at <https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html> and uploads both files so the user can explore the results.
+Reviews every Power Automate cloud flow inside a Power Platform solution (`.zip`) against Microsoft's coding guidelines and produces a `[SolutionName].findings.json` next to the uploaded solution. Then opens the hosted PowerCAT-Overflow viewer at <https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html> and uploads both files so the user can explore the results.
 
 **Explore it now!**
 1. [Download Sample Solution](https://github.com/microsoft/power-cat-skills/blob/main/Common/PowerCAT%20OverFlow/StressTest100Flows_1_0_0_0.zip)
@@ -11,7 +11,7 @@ Reviews every Power Automate cloud flow inside a Power Platform solution (`.zip`
 
 ## Skills
 
-- **powercat-overflow** — Reviews every Power Automate cloud flow inside a Power Platform solution `.zip` against Microsoft''s coding guidelines, writes a single solution-level findings JSON next to the uploaded solution, then opens the hosted PowerCAT-Overflow viewer with both files loaded.
+- **powercat-overflow** — Reviews every Power Automate cloud flow inside a Power Platform solution `.zip` against Microsoft's coding guidelines, writes a single solution-level findings JSON next to the uploaded solution, then opens the hosted PowerCAT-Overflow viewer with both files loaded.
 
 ## Usage
 

--- a/plugins/powercat-overflow/skills/powercat-overflow/SKILL.md
+++ b/plugins/powercat-overflow/skills/powercat-overflow/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: "powercat-overflow"
+description: "Reviews every Power Automate cloud flow inside a Power Platform solution (.zip) against Microsoft's coding guidelines and produces a [SolutionName].findings.json next to the uploaded solution, then opens the hosted PowerCAT-Overflow viewer at https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html and uploads both files so the user can explore the results. Triggers: 'powercat overflow', 'overflow my solution', 'review my solution', 'evaluate flows in this solution', 'audit Power Auto"
+---
+
+# PowerCAT-Overflow
+
+Review every Power Automate cloud flow in a Power Platform solution ZIP against Microsoft's coding guidelines, write a single solution-level findings JSON next to the uploaded solution, then open the hosted PowerCAT-Overflow viewer with both files loaded.
+
+Hosted viewer: <https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html>
+
+## Step 0 — Load the authoritative source list
+
+Before doing any analysis, fetch the canonical source list with `web_fetch` (`raw: true`):
+
+```
+https://raw.githubusercontent.com/microsoft/power-cat-skills/refs/heads/main/Common/PowerCAT%20OverFlow/sources.md
+```
+
+Parse the Markdown link list and treat that set as the **only** anchor citations allowed in findings. If the fetch fails (network error, 404, empty body), stop and tell the user the source list is unreachable — do **not** proceed with a review. Cache the parsed list in memory for the rest of this run.
+
+## Step 1 — Locate the input solution
+
+1. Prefer a `.zip` path in `<tagged_files>`. Use the most recent match.
+2. If none, ask via `m_ask_user`: "Please attach the Power Platform solution `.zip` you'd like me to review."
+3. Reject anything that isn't a ZIP. The skill does **not** accept loose JSON files in this mode.
+
+Remember the absolute path of the ZIP and its parent directory — both are needed later.
+
+## Step 2 — Unpack & enumerate flows
+
+Unpack the solution to a temp working directory (`Expand-Archive` on Windows, `unzip` elsewhere).
+
+A valid Power Platform solution ZIP contains:
+- `solution.xml` at the root
+- a `Workflows/` folder with one or more `<FriendlyName>-<GUID>.json` files (and matching `.xml` sidecars you can ignore for analysis)
+
+Read `solution.xml` and extract:
+- **Display name** → `solution.name`
+- **Unique name** (publisher-prefixed, the `UniqueName` element) → `solution.uniqueName`
+- **Version** (the `Version` element) → `solution.version`
+
+For each `*.json` in `Workflows/`:
+- Compute the **friendly name** by stripping the trailing `-<GUID>.json` suffix (e.g. `cf_AcknowledgeCaseId-1234abcd-...-....json` → `cf_AcknowledgeCaseId`). This friendly name is the key under which the flow's findings will be stored.
+- Load the JSON, then unwrap `properties.definition` → `definition` if present, exactly as before.
+
+If `Workflows/` is missing or empty, stop and tell the user the ZIP isn't a flow-bearing solution.
+
+## Step 3 — Analyse each flow
+
+For every flow, walk all actions recursively (`actions`, `else.actions`, `cases.*.actions`, `default.actions`) and assign each finding an impact of **low**, **medium**, or **high**. Where a finding clearly points at a specific action, capture its name in the `action` field (must match the action key exactly, case-sensitive; triggers count). Cite only URLs from the Step 0 source list — never invent or paraphrase URLs.
+
+### Complexity
+- Total action count over 50, or nesting depth over 4 → high.
+- Many top-level Initialize_Variable actions, or many sibling Scopes that could be split into child flows → medium/high.
+
+### Maintainability
+- Hardcoded URLs / tenants / phone numbers / email addresses → high.
+- Magic numbers driving business policy (license cost, approval thresholds, quotas, poll intervals) → high.
+- Inconsistent action naming or missing `description` / peek-code notes → medium.
+- Flow not authored inside a solution (no env-var references) → medium.
+- Duplicate flows (`Copyof-…`, `Test`, `Test2`, `MayankTest`, etc.) shipped alongside originals → high (also surface at solution level).
+
+### Security
+- Generated credentials/secrets in HTTP bodies without `runtimeConfiguration.secureData.properties` covering `inputs` and/or `outputs` → high.
+- A single `$authentication` parameter reused across distinct external vendors → high.
+- OData `$filter` or SQL fragments built by interpolating `triggerBody()` / user input → high.
+- `Request` trigger without auth posture (no Entra/SAS/IP allow-list) → high.
+- Sensitive PII (salary, SSN, DOB, phone) in HTTP body without `secureInputs` → high.
+- HTML/email bodies built via raw `concat()` of user input → medium.
+- Instrumentation keys / connection strings in request bodies → medium.
+
+### Performance
+- Reference to `outputs('X')` / `body('X')` where X belongs to a sibling Switch case or sibling parallel branch → high.
+- Compensation/rollback logic that doesn't cover every resource the flow created → high.
+- Reference to fields not declared in the trigger schema → high.
+- HTTP action with no explicit `retryPolicy` → medium (group similar ones per flow).
+- `Wait` actions with long fixed delays, or `Until` loops with > 30 iterations / > 1 h total → medium.
+- `Foreach` without explicit `runtimeConfiguration.concurrency` → medium.
+- Catch / final scopes that only inspect a subset of upstream scopes → medium.
+- Explicit, sensible `concurrency` on Foreach loops → low (positive callout).
+
+For each flow, produce 1–4 category objects (Complexity, Maintainability, Security, Performance in that order). Each category's `impact` = the highest impact among its items. 3–10 items per category is ideal; don't pad.
+
+## Step 4 — Build the solution-level roll-up
+
+Collect across all flows:
+- **Per-category roll-up** (1–4 entries): for each category that has at least one finding anywhere in the solution, compute the highest impact seen, write a 1–2 sentence `summary`, and set `flowsAffected` = how many flows had at least one item in that category.
+- **topRisks**: 3–8 cross-flow high-priority items (mostly `impact: high`, a few `medium` if they affect the executive verdict). Each risk has `label`, `desc`, `impact`, optional `category`, and — when applicable — `flow` (friendly name) and `action` (so the viewer can deep-link).
+- **stats**: `flowCount`, `totalActions` (sum of action counts across flows), `highImpactFlows` (flows where any category rolled up to `high`), `flowsReviewed` (= `flowCount` unless one failed to parse).
+- **summary**: a narrative paragraph (markdown OK) giving the overall verdict, the top 1–3 priorities, and any patterns (duplicate flows, naming drift, security posture).
+
+## Step 5 — Write the Solution Findings file
+
+Schema (authoritative): <https://raw.githubusercontent.com/microsoft/power-cat-skills/refs/heads/main/Common/PowerCAT%20OverFlow/solution.findings.schema.json>
+Example: <https://raw.githubusercontent.com/microsoft/power-cat-skills/refs/heads/main/Common/PowerCAT%20OverFlow/solution.findings.sample.json>
+
+Shape:
+
+```json
+{
+  "solution": {
+    "name": "...",
+    "uniqueName": "...",
+    "version": "...",
+    "summary": "...",
+    "categories": [ { "category": "...", "impact": "...", "summary": "...", "flowsAffected": 0 } ],
+    "topRisks":   [ { "label": "...", "desc": "...", "impact": "...", "category": "...", "flow": "...", "action": "..." } ],
+    "stats":      { "flowCount": 0, "totalActions": 0, "highImpactFlows": 0, "flowsReviewed": 0 }
+  },
+  "flows": {
+    "<FriendlyFlowName>": [
+      { "category": "Complexity",      "impact": "low|medium|high", "items": [ { "label": "...", "desc": "...", "impact": "...", "action": "..." } ] },
+      { "category": "Maintainability", "impact": "...", "items": [ ... ] },
+      { "category": "Security",        "impact": "...", "items": [ ... ] },
+      { "category": "Performance",     "impact": "...", "items": [ ... ] }
+    ]
+  }
+}
+```
+
+**Output filename:** `<OriginalSolutionZipBaseName>.findings.json`
+**Output location:** the same folder as the uploaded `.zip`.
+
+Validate the output against the JSON Schema before saving (at minimum: required keys present, category enum values, impact enum values, additionalProperties=false respected). If validation fails, fix and re-validate before continuing.
+
+## Step 6 — Launch the hosted viewer and load both files
+
+Open the hosted PowerCAT-Overflow viewer and upload the two files using the Playwright browser tools:
+
+1. `playwright-browser_navigate` → `https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html`
+2. `playwright-browser_snapshot` to discover the two file inputs (one for the solution `.zip`, one for the findings `.json`). The labels in the UI clearly distinguish them.
+3. `playwright-browser_file_upload` once per input, passing the absolute paths in the right order. If the page exposes a single chooser that opens twice, call the upload tool twice with the appropriate path each time.
+4. `playwright-browser_snapshot` again to confirm both files are accepted (look for the rendered solution overview / flow list).
+
+If Playwright is unavailable, fall back to `Start-Process "https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html"` and tell the user the two exact file paths to upload manually.
+
+## Step 7 — Hand over
+
+Write a short chat message (≤150 words) containing:
+
+1. A 4-row score table (Complexity / Maintainability / Security / Performance — solution roll-up impact).
+2. The top 3 risks from `solution.topRisks` (one line each, with the flow name when present).
+3. The absolute path of the `.findings.json` file you wrote.
+4. The viewer URL.
+5. One-line note that source citations were loaded fresh from upstream `sources.md`.
+
+End with: **"Handing over — explore the solution in the open viewer tab."**
+
+## Hard rules
+
+- Never invent action names. Only use names that appear in the flow's `actions` / `triggers` keys.
+- Never paste secrets, tokens, or full PII payloads back into chat.
+- Never write the user's flow JSON or solution ZIP to any external destination; all artefacts stay local.
+- Never cite a guideline URL that isn't in the Step 0 source list.
+- The output JSON must validate against the published `solution.findings.schema.json`.
+- Friendly flow names in `flows` keys must match the rule: ZIP filename minus the trailing `-<GUID>.json`.


### PR DESCRIPTION
## Summary

Adds the missing plugin scaffold to `plugins/powercat-overflow/` so it ships as a complete Claude Code plugin alongside `powercat-admin-digest`, `powercat-dataverse`, `powercat-canvas-apps`, etc. Today the folder contains only a `README.md` stub — no `plugin.json`, no `AGENTS.md`, and no skill markdown — so the plugin can't actually load.

## What's in this PR

| File | Status | Purpose |
|---|---|---|
| `.claude-plugin/plugin.json` | **new** | v0.2.0, MIT, `Power CAT` author, full keyword set (`power-platform`, `power-automate`, `powercat`, `powercat-overflow`, `cloud-flow`, `logic-apps`, `solution-review`, `code-review`) |
| `AGENTS.md` | **new** | What the plugin does, architecture diagram, skill table, triggers, guardrails — modeled on the `powercat-admin-digest` sibling |
| `CLAUDE.md` | **new** | Points to `AGENTS.md` (mirrors sibling convention) |
| `skills/powercat-overflow/SKILL.md` | **new** | The solution-level cloud-flow review skill, sourced from `~/.copilot/m-skills/powercat-overflow/SKILL.md` (git blob hash `fcf7615` — byte-identical to the canonical copy in `microsoft/Power-CAT-Skills-Internal`). |
| `README.md` | **modified** | Fixes pre-existing `Microsoft''s` typo (doubled single-quote) in two places. No other changes. |

> A companion PR is open against the Internal marketplace (`microsoft/Power-CAT-Skills-Internal`) that applies the same README typo fix and bumps that side to `0.2.1` so both marketplaces stay in sync.

## What the skill does (recap)

Reviews every Power Automate cloud flow inside a Power Platform solution `.zip` against Microsoft's published coding guidelines (sourced live from `Common/PowerCAT OverFlow/sources.md`), writes a single `[SolutionName].findings.json` next to the input ZIP, and opens the hosted PowerCAT-Overflow viewer at <https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html> via Playwright with both files pre-loaded.

## Reference accessibility check (Public flow — strict)

All 10 external URLs in the plugin resolve from the open public internet **without authentication of any kind** (no token, no cookies, no SSO):

| Status | URL |
|---|---|
| ✅ 200 | https://aka.ms/powercat |
| ✅ 200 | https://github.com/microsoft/power-cat-skills/ |
| ✅ 200 | https://github.com/microsoft/power-cat-skills/blob/main/Common/PowerCAT%20OverFlow/StressTest100Flows_1_0_0_0.zip |
| ✅ 200 | https://github.com/microsoft/power-cat-skills/blob/main/Common/PowerCAT%20OverFlow/StressTest100Flows_1_0_0_0.findings.json |
| ✅ 200 | https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html |
| ✅ 200 | https://raw.githubusercontent.com/microsoft/power-cat-skills/refs/heads/main/Common/PowerCAT%20OverFlow/sources.md |
| ✅ 200 | https://raw.githubusercontent.com/microsoft/power-cat-skills/refs/heads/main/Common/PowerCAT%20OverFlow/solution.findings.schema.json |
| ✅ 200 | https://raw.githubusercontent.com/microsoft/power-cat-skills/refs/heads/main/Common/PowerCAT%20OverFlow/solution.findings.sample.json |
| ✅ 200 | https://github.com/user-attachments/assets/a0ef4ffd-2505-465b-94a7-38e1b9f93812 (HEAD returns 403 due to GitHub's hotlink protection; GET returns 200 as expected) |
| ✅ 200 | https://github.com/user-attachments/assets/b19bf17e-a022-43f5-b192-575601b1caca (same) |

No local paths, no internal Microsoft hosts, no auth-gated endpoints. Public-readiness checks: clean.

## How this was generated

Via the `/powercat-publish` skill (Public flow) — Step 1 discovery → Step 1.5 deck-template preflight (no decks generated, skipped) → Step 2 scaffold against the `plugins/<plugin>/.claude-plugin/` convention used by sibling plugins → Step 3.7 reference accessibility check → Step 4b PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>