### PR TITLE
Register powercat-overflow plugin in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -122,6 +122,23 @@
         "admin", "message center", "service health",
         "deprecations", "power platform", "powercat", "microsoft"
       ]
+    },
+    {
+      "name": "powercat-overflow",
+      "description": "Reviews every Power Automate cloud flow inside a Power Platform solution (.zip) against Microsoft's coding guidelines, produces a [SolutionName].findings.json next to the uploaded solution, then opens the hosted PowerCAT-Overflow viewer at https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html and uploads both files so the user can explore the results.",
+      "source": "./plugins/powercat-overflow",
+      "skills": [
+        "./plugins/powercat-overflow/skills/powercat-overflow"
+      ],
+      "version": "0.2.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "power-platform", "power-automate", "powercat",
+        "powercat-overflow", "cloud-flow", "logic-apps",
+        "solution-review", "code-review", "microsoft"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Problem

Audited the marketplace and noticed plugins/powercat-overflow/ exists in the repo (added via #19) but it was never registered in .claude-plugin/marketplace.json, so it doesn't show up in the marketplace listing.

## Fix

Added the missing powercat-overflow entry to .claude-plugin/marketplace.json, mirroring the structure of the other plugins. Metadata (version 