### PR TITLE
Register powercat-overflow in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -122,6 +122,23 @@
         "admin", "message center", "service health",
         "deprecations", "power platform", "powercat", "microsoft"
       ]
+    },
+    {
+      "name": "powercat-overflow",
+      "description": "Reviews every Power Automate cloud flow inside a Power Platform solution (.zip) against Microsoft's coding guidelines and produces a [SolutionName].findings.json next to the uploaded solution, then opens the hosted PowerCAT-Overflow viewer at https://microsoft.github.io/power-cat-skills/PowerCAT-Overflow.html and uploads both files so the user can explore the results.",
+      "source": "./plugins/powercat-overflow",
+      "skills": [
+        "./plugins/powercat-overflow/skills/powercat-overflow"
+      ],
+      "version": "0.2.0",
+      "repository": "https://github.com/microsoft/power-cat-skills",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "power platform", "power automate", "cloud flow",
+        "logic apps", "solution review", "code review",
+        "powercat", "microsoft"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What this PR does

Adds the missing `powercat-overflow` entry to `.claude-plugin/marketplace.json` so the plugin is actually discoverable.

## Why

[PR #19](https://github.com/microsoft/power-cat-skills/pull/19) merged the `plugins/powercat-overflow/` folder cleanly on 2026-06-11 — but never appended the plugin to the marketplace registry. As a result:

- `plugins/powercat-overflow/{.claude-plugin/plugin.json, AGENTS.md, CLAUDE.md, README.md, skills/powercat-overflow/SKILL.md}` are on `main` ✅
- `.claude-plugin/marketplace.json` still lists 7 plugins (not 8) ❌
- `copilot plugin marketplace add microsoft/power-cat-skills` followed by `plugin list` does **not** show `powercat-overflow`

Files on disk ≠ published.

## What changed

Single edit: appended one entry (17 lines) to the `plugins[]` array in `.claude-plugin/marketplace.json`. Schema matches the 7 existing entries exactly (`name`, `description`, `source`, `skills[]`, `version`, `repository`, `license`, `category`, `tags`). Version `0.2.0` matches what's already in `plugins/powercat-overflow/.claude-plugin/plugin.json` on `main`.

## Validation already done

- ✅ Modified manifest round-trips through `ConvertFrom-Json` cleanly, 8 plugins total
- ✅ `source` path (`./plugins/powercat-overflow`) confirmed to exist on `main` from PR #19
- ✅ `skills[]` entry path (`./plugins/powercat-overflow/skills/powercat-overflow`) confirmed to contain `SKILL.md`
- ✅ `version` matches `plugins/powercat-overflow/.claude-plugin/plugin.json`

## Post-merge validation (for the reviewer)

```
curl -fsSL https://raw.githubusercontent.com/microsoft/power-cat-skills/main/.claude-plugin/marketplace.json \
  | jq '.plugins | length, (.[] | select(.name == "powercat-overflow"))'
```

Should print `8` followed by the powercat-overflow entry.

End-to-end install check:

```
copilot plugin marketplace add microsoft/power-cat-skills
copilot plugin list --marketplace power-cat-skills | grep powercat-overflow
```

Should list the plugin.

## Companion PR

Companion PR opened in [microsoft/Power-CAT-Skills-Internal#122](https://github.com/microsoft/Power-CAT-Skills-Internal/pull/122) bumps the `/powercat-publish` skill itself to **v0.2.0** so this class of bug — *plugin files merged, manifest registration silently skipped* — cannot recur. The new flow:

1. Probes **both** canonical manifest paths (`.claude-plugin/marketplace.json` for the Claude Code spec; `marketplace.json` at the repo root for the legacy layout) and picks the first one that exists.
2. Refuses to silently skip registration — stops and asks if neither manifest path exists.
3. Emits a post-merge discoverability validation block in every publish PR body (raw-content `curl` + `jq` against the manifest plus a `copilot plugin marketplace add` / `plugin list` recipe).

## Notes for reviewers

- Internal already had `powercat-overflow @ 0.2.1` registered correctly (via [Power-CAT-Skills-Internal#113](https://github.com/microsoft/Power-CAT-Skills-Internal/pull/113), merged) — only Public was affected by the original bug.
- This is a registry-add only. No changes to the plugin folder itself; no new plugin code.