### PR TITLE
feat(overflow): add fix field to findings — schema, viewer, skill

### DIFF
--- a/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
+++ b/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
@@ -749,6 +749,15 @@ main.layout.solution-overview-mode.no-solution-loaded .canvas-pane {
   font-size: 12px;
   margin-top: 2px;
 }
+.finding .text .fix {
+  display: block;
+  color: var(--cp-accent);
+  font-size: 12px;
+  margin-top: 5px;
+}
+.finding .text .fix-label {
+  font-weight: 700;
+}
 .report-score {
   display: flex;
   gap: 8px;
@@ -1659,7 +1668,9 @@ function renderReport() {
       const arrow = item.action ? '<span class="jump-arrow" title="Jump to ' + escapeHtml(item.action) + '">\u2197</span>' : '';
       f.innerHTML = '<span class="dot ' + item.impact + '" title="' + item.impact + '"></span>' +
         '<div class="text"><span class="label">' + escapeHtml(item.label) + arrow + '</span>' +
-        '<span class="desc">' + escapeHtml(item.desc) + '</span></div>';
+        '<span class="desc">' + escapeHtml(item.desc) + '</span>' +
+        (item.fix ? '<span class="fix"><span class="fix-label">Fix</span> \u00B7 ' + escapeHtml(item.fix) + '</span>' : '') +
+        '</div>';
       if (item.action) {
         f.dataset.target = item.action;
         f.addEventListener("click", () => jumpToAction(item.action));
@@ -3407,7 +3418,9 @@ function renderSolutionOverviewCanvas() {
             '</div>' +
             '<span class="impact-pill ' + r.impact + '">' + impactLabel + '</span>' +
           '</div>' +
-          '<div class="action-body">' + escapeHtml(r.desc) + jump + '</div>' +
+          '<div class="action-body">' + escapeHtml(r.desc) +
+          (r.fix ? '<div class="fix" style="margin-top:5px;"><span class="fix-label">Fix</span> \u00B7 ' + escapeHtml(r.fix) + '</div>' : '') +
+          jump + '</div>' +
         '</div>';
     }
     risksContainer =

--- a/Common/PowerCAT OverFlow/solution.findings.schema.json
+++ b/Common/PowerCAT OverFlow/solution.findings.schema.json
@@ -78,6 +78,10 @@
               "action": {
                 "type": "string",
                 "description": "Optional action name inside the referenced flow that the risk points at. Used to deep-link to the action card in the diagram."
+              },
+              "fix": {
+                "type": "string",
+                "description": "Single-sentence actionable remediation step for this top-risk item."
               }
             }
           }
@@ -124,6 +128,10 @@
                   "action": {
                     "type": "string",
                     "description": "Optional name of the action inside the flow that the finding points to."
+                  },
+                  "fix": {
+                    "type": "string",
+                    "description": "Single-sentence actionable remediation step — what the developer should do to resolve this finding. Start with a verb (e.g. 'Enable secure inputs on…', 'Replace the hardcoded URL with an environment variable named…')."
                   }
                 }
               }

--- a/plugins/powercat-overflow/skills/powercat-overflow/SKILL.md
+++ b/plugins/powercat-overflow/skills/powercat-overflow/SKILL.md
@@ -82,11 +82,16 @@ For every flow, walk all actions recursively (`actions`, `else.actions`, `cases.
 
 For each flow, produce 1–4 category objects (Complexity, Maintainability, Security, Performance in that order). Each category's `impact` = the highest impact among its items. 3–10 items per category is ideal; don't pad.
 
+For every finding **item**, always include a `fix` field — a single actionable sentence (≤ 30 words, start with a verb) telling the developer exactly what to change. Examples:
+- `"Enable secure inputs on HTTP action 'Send_Request' via Settings → Secure Inputs."`
+- `"Replace the hardcoded URL in 'Initialize_Variable_Endpoint' with an environment variable."`
+- `"Add concurrency (recommend: 10) to the Apply-to-each in its Settings panel."`
+
 ## Step 4 — Build the solution-level roll-up
 
 Collect across all flows:
 - **Per-category roll-up** (1–4 entries): for each category that has at least one finding anywhere in the solution, compute the highest impact seen, write a 1–2 sentence `summary`, and set `flowsAffected` = how many flows had at least one item in that category.
-- **topRisks**: 3–8 cross-flow high-priority items (mostly `impact: high`, a few `medium` if they affect the executive verdict). Each risk has `label`, `desc`, `impact`, optional `category`, and — when applicable — `flow` (friendly name) and `action` (so the viewer can deep-link).
+- **topRisks**: 3–8 cross-flow high-priority items (mostly `impact: high`, a few `medium` if they affect the executive verdict). Each risk has `label`, `desc`, `impact`, optional `category`, optional `fix` (same single-sentence remediation convention as per-flow items), and — when applicable — `flow` (friendly name) and `action` (so the viewer can deep-link).
 - **stats**: `flowCount`, `totalActions` (sum of action counts across flows), `highImpactFlows` (flows where any category rolled up to `high`), `flowsReviewed` (= `flowCount` unless one failed to parse).
 - **summary**: a narrative paragraph (markdown OK) giving the overall verdict, the top 1–3 priorities, and any patterns (duplicate flows, naming drift, security posture).
 
@@ -105,12 +110,12 @@ Shape:
     "version": "...",
     "summary": "...",
     "categories": [ { "category": "...", "impact": "...", "summary": "...", "flowsAffected": 0 } ],
-    "topRisks":   [ { "label": "...", "desc": "...", "impact": "...", "category": "...", "flow": "...", "action": "..." } ],
+    "topRisks":   [ { "label": "...", "desc": "...", "fix": "...", "impact": "...", "category": "...", "flow": "...", "action": "..." } ],
     "stats":      { "flowCount": 0, "totalActions": 0, "highImpactFlows": 0, "flowsReviewed": 0 }
   },
   "flows": {
     "<FriendlyFlowName>": [
-      { "category": "Complexity",      "impact": "low|medium|high", "items": [ { "label": "...", "desc": "...", "impact": "...", "action": "..." } ] },
+      { "category": "Complexity",      "impact": "low|medium|high", "items": [ { "label": "...", "desc": "...", "fix": "...", "impact": "...", "action": "..." } ] },
       { "category": "Maintainability", "impact": "...", "items": [ ... ] },
       { "category": "Security",        "impact": "...", "items": [ ... ] },
       { "category": "Performance",     "impact": "...", "items": [ ... ] }


### PR DESCRIPTION
## What this PR does

Adds a `fix` field to the PowerCAT OverFlow findings schema, viewer, and skill so every finding now shows — right below the description — a single actionable sentence telling the developer exactly what to change.

## Screenshot reference

The "Fix · <text>" pattern below the finding description, styled in the accent colour (pink), matches the requested design.

## Changes

### Viewer — `Common/PowerCAT OverFlow/PowerCAT-Overflow.html`

| Area | Change |
|------|--------|
| **CSS** | New `.finding .text .fix` rule — accent colour, 12px, `margin-top: 5px`. New `.fix-label` rule — bold weight for the "Fix" prefix. |
| **Per-flow findings panel** | Appends `<span class="fix"><span class="fix-label">Fix</span> · <fix text></span>` after the `.desc` when `item.fix` is present. |
| **Top-risks panel** | Appends a `.fix` div inside `.action-body` when `risk.fix` is present. |
| **Backwards compat** | Findings JSON without `fix` render identically to before — the field is optional everywhere. |

### Schema — `Common/PowerCAT OverFlow/solution.findings.schema.json`

- Added optional `"fix"` string to `flows[*].items[*]`
- Added optional `"fix"` string to `solution.topRisks[*]`
- `additionalProperties: false` preserved; existing JSON files remain valid

### Skill — `plugins/powercat-overflow/skills/powercat-overflow/SKILL.md`

- **Step 3**: new paragraph requiring a `fix` on every finding item — single verb-led sentence (≤ 30 words) with three concrete examples
- **Step 4**: topRisks bullet updated to mention optional `fix`
- **Step 5**: shape comments updated to show `fix` in items and topRisks

## Validation

- Schema round-trips through JSON parser cleanly
- HTML: all 4 fix-related patterns verified (`CSS block`, `.fix-label`, `item.fix`, `r.fix`)
- SKILL.md: `fix` field instruction, topRisks shape, and items shape all confirmed present
- `git diff --stat`: +31/−5 across 3 files

## Post-merge

The local `~/.copilot/m-skills/powercat-overflow/SKILL.md` should be synced (or will auto-update on next plugin install) to pick up the new `fix` output requirement.