### PR TITLE
feat(overflow): collapsible code viewer panel

### DIFF
--- a/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
+++ b/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
@@ -824,6 +824,42 @@ body.col-resizing * {
   font-size: 12px;
   color: var(--cp-text-soft);
 }
+.editor-toggle-btn {
+  flex: 0 0 auto;
+  background: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  color: var(--cp-text-muted);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  line-height: 1;
+  margin-left: 6px;
+  transition: transform 0.18s ease;
+}
+.editor-toggle-btn:hover { border-color: var(--cp-border); background: var(--cp-accent-soft); color: var(--cp-text); }
+/* Collapsed editor pane */
+main.layout.editor-collapsed {
+  grid-template-columns: var(--flownav-current) 32px 0 1fr var(--report-width) !important;
+}
+main.layout.editor-collapsed #splitter { display: none; }
+main.layout.editor-collapsed .editor-pane { overflow: hidden; }
+main.layout.editor-collapsed .editor-header {
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  width: 32px;
+  padding: 8px 0;
+  border-bottom: none;
+  border-right: 1px solid var(--cp-border);
+  justify-content: flex-start;
+  box-sizing: border-box;
+}
+main.layout.editor-collapsed .editor-title,
+main.layout.editor-collapsed .editor-header .hint,
+main.layout.editor-collapsed #jsonEditor,
+main.layout.editor-collapsed .error-message { display: none; }
+main.layout.editor-collapsed .editor-toggle-btn { transform: rotate(180deg); }
 #jsonEditor {
   flex: 1;
   width: 100%;
@@ -1403,8 +1439,9 @@ body.col-resizing * {
   </nav>
   <section class="editor-pane">
     <div class="editor-header">
-      <span>Workflow Definition (JSON)</span>
+      <span class="editor-title">Workflow Definition (JSON)</span>
       <span class="hint">Auto-updates as you type</span>
+      <button class="editor-toggle-btn" id="editorToggleBtn" title="Collapse code viewer" aria-label="Toggle code viewer">&#x25C0;</button>
     </div>
     <div id="jsonEditor"></div>
     <div class="error-message" id="errorMessage"></div>
@@ -3609,6 +3646,20 @@ function initPan() {
 }
 
 document.addEventListener("DOMContentLoaded", init);
+// Editor pane collapse toggle — persisted in localStorage
+document.addEventListener("DOMContentLoaded", function initEditorToggle() {
+  const btn = document.getElementById("editorToggleBtn");
+  const layout = document.querySelector("main.layout");
+  if (!btn || !layout) return;
+  function applyCollapsed(collapsed) {
+    layout.classList.toggle("editor-collapsed", collapsed);
+    btn.title = collapsed ? "Expand code viewer" : "Collapse code viewer";
+    try { if (typeof aceEditor !== "undefined" && aceEditor) aceEditor.resize(); } catch {}
+    try { localStorage.setItem("overflow.editorCollapsed", collapsed ? "1" : "0"); } catch {}
+  }
+  btn.addEventListener("click", () => applyCollapsed(!layout.classList.contains("editor-collapsed")));
+  try { if (localStorage.getItem("overflow.editorCollapsed") === "1") applyCollapsed(true); } catch {}
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## What this PR does

Makes the **Workflow Definition (JSON)** (Ace editor) panel collapsible so users can reclaim screen real estate for the flow diagram when they don't need to read or edit the raw JSON.

## How it works

A **◀** toggle button appears in the editor panel header. Click it to collapse; click again (now showing **▶**) to expand. State is persisted in `localStorage` so the preference survives page refresh.

| State | Behaviour |
|-------|-----------|
| Expanded (default) | 380 px Ace editor, splitter visible, full existing UX |
| Collapsed | Editor column narrows to 32 px, splitter hidden, `#jsonEditor` / `.error-message` / title / hint hidden; only the toggle button remains visible; `aceEditor.resize()` called on expand so the gutter redraws cleanly |

## Changes — `Common/PowerCAT OverFlow/PowerCAT-Overflow.html` only (+52/−1)

**HTML**  
- Wrapped the header title in `<span class="editor-title">` (so it can be hidden independently)  
- Added `<button id="editorToggleBtn">` with `◀` glyph, accessible `title` + `aria-label`, and a hover style

**CSS**  
- `.editor-toggle-btn` — minimal button reset, accent-soft hover, `transition: transform 0.18s ease`  
- `main.layout.editor-collapsed` — overrides `grid-template-columns` with `!important` (col 2 = 32 px, col 3 [splitter] = 0); hides splitter, jsonEditor, error-message, editor-title, hint; collapses header to a 32 px strip; rotates button 180°

**JS** (second `DOMContentLoaded` listener)  
- `initEditorToggle()` hooks the button, reads/writes `localStorage.overflow.editorCollapsed`, calls `aceEditor.resize()` after expanding

## Compatibility

- `solution-overview-mode` already hides `.editor-pane` with its own `!important` — no conflict
- No changes to findings JSON schema, skill, or any other file