### PR TITLE
feat(overflow): add fix field to findings — schema + viewer (both copies)

### DIFF
--- a/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
+++ b/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
@@ -749,6 +749,15 @@ main.layout.solution-overview-mode.no-solution-loaded .canvas-pane {
   font-size: 12px;
   margin-top: 2px;
 }
+.finding .text .fix {
+  display: block;
+  color: var(--cp-accent);
+  font-size: 12px;
+  margin-top: 5px;
+}
+.finding .text .fix-label {
+  font-weight: 700;
+}
 .report-score {
   display: flex;
   gap: 8px;
@@ -1696,7 +1705,9 @@ function renderReport() {
       const arrow = item.action ? '<span class="jump-arrow" title="Jump to ' + escapeHtml(item.action) + '">\u2197</span>' : '';
       f.innerHTML = '<span class="dot ' + item.impact + '" title="' + item.impact + '"></span>' +
         '<div class="text"><span class="label">' + escapeHtml(item.label) + arrow + '</span>' +
-        '<span class="desc">' + escapeHtml(item.desc) + '</span></div>';
+        '<span class="desc">' + escapeHtml(item.desc) + '</span>' +
+        (item.fix ? '<span class="fix"><span class="fix-label">Fix</span> · ' + escapeHtml(item.fix) + '</span>' : '') +
+        '</div>';
       if (item.action) {
         f.dataset.target = item.action;
         f.addEventListener("click", () => jumpToAction(item.action));
@@ -3444,7 +3455,9 @@ function renderSolutionOverviewCanvas() {
             '</div>' +
             '<span class="impact-pill ' + r.impact + '">' + impactLabel + '</span>' +
           '</div>' +
-          '<div class="action-body">' + escapeHtml(r.desc) + jump + '</div>' +
+          '<div class="action-body">' + escapeHtml(r.desc) +
+          (r.fix ? '<div class="fix" style="margin-top:5px;"><span class="fix-label">Fix</span> · ' + escapeHtml(r.fix) + '</div>' : '') +
+          jump + '</div>' +
         '</div>';
     }
     risksContainer =

--- a/Common/PowerCAT OverFlow/solution.findings.schema.json
+++ b/Common/PowerCAT OverFlow/solution.findings.schema.json
@@ -78,6 +78,10 @@
               "action": {
                 "type": "string",
                 "description": "Optional action name inside the referenced flow that the risk points at. Used to deep-link to the action card in the diagram."
+              },
+              "fix": {
+                "type": "string",
+                "description": "Single-sentence actionable remediation step for this top-risk item."
               }
             }
           }
@@ -124,6 +128,10 @@
                   "action": {
                     "type": "string",
                     "description": "Optional name of the action inside the flow that the finding points to."
+                  },
+                  "fix": {
+                    "type": "string",
+                    "description": "Single-sentence actionable remediation step."
                   }
                 }
               }

--- a/docs/PowerCAT-Overflow.html
+++ b/docs/PowerCAT-Overflow.html
@@ -749,6 +749,15 @@ main.layout.solution-overview-mode.no-solution-loaded .canvas-pane {
   font-size: 12px;
   margin-top: 2px;
 }
+.finding .text .fix {
+  display: block;
+  color: var(--cp-accent);
+  font-size: 12px;
+  margin-top: 5px;
+}
+.finding .text .fix-label {
+  font-weight: 700;
+}
 .report-score {
   display: flex;
   gap: 8px;
@@ -1695,7 +1704,9 @@ function renderReport() {
       const arrow = item.action ? '<span class="jump-arrow" title="Jump to ' + escapeHtml(item.action) + '">\u2197</span>' : '';
       f.innerHTML = '<span class="dot ' + item.impact + '" title="' + item.impact + '"></span>' +
         '<div class="text"><span class="label">' + escapeHtml(item.label) + arrow + '</span>' +
-        '<span class="desc">' + escapeHtml(item.desc) + '</span></div>';
+        '<span class="desc">' + escapeHtml(item.desc) + '</span>' +
+        (item.fix ? '<span class="fix"><span class="fix-label">Fix</span> · ' + escapeHtml(item.fix) + '</span>' : '') +
+        '</div>';
       if (item.action) {
         f.dataset.target = item.action;
         f.addEventListener("click", () => jumpToAction(item.action));
@@ -3443,7 +3454,9 @@ function renderSolutionOverviewCanvas() {
             '</div>' +
             '<span class="impact-pill ' + r.impact + '">' + impactLabel + '</span>' +
           '</div>' +
-          '<div class="action-body">' + escapeHtml(r.desc) + jump + '</div>' +
+          '<div class="action-body">' + escapeHtml(r.desc) +
+          (r.fix ? '<div class="fix" style="margin-top:5px;"><span class="fix-label">Fix</span> · ' + escapeHtml(r.fix) + '</div>' : '') +
+          jump + '</div>' +
         '</div>';
     }
     risksContainer =


### PR DESCRIPTION
## What this PR does

Adds a `fix` field to the findings schema and viewer so each finding shows a **"Fix · <text>"** line in the accent colour below the description — a single actionable sentence telling the developer exactly what to change.

## Changes

### Schema — `Common/PowerCAT OverFlow/solution.findings.schema.json`

- Optional `"fix"` string added to `flows[*].items[*]`
- Optional `"fix"` string added to `solution.topRisks[*]`
- `additionalProperties: false` preserved — old `.findings.json` files remain valid

### Viewer — both copies (identical change)

`Common/PowerCAT OverFlow/PowerCAT-Overflow.html` + `docs/PowerCAT-Overflow.html`

| Area | Change |
|------|--------|
| **CSS** | `.finding .text .fix` — accent colour, 12 px, `margin-top: 5px`. `.finding .text .fix-label` — bold "Fix" prefix. |
| **Per-flow findings panel** | Appends `<span class="fix">…</span>` after `.desc` when `item.fix` is present |
| **Top-risks panel** | Appends `.fix` div inside `.action-body` when `r.fix` is present |
| **Backwards compat** | Findings JSON without `fix` renders identically to before |

## Validation

- All 3 HTML patches confirmed present in both copies (CSS, JS-desc, JS-risk)
- Schema round-trips through JSON parser; `"fix"` visible in both `items` and `topRisks` properties
- `git diff --stat`: +38/−4 across 3 files