### PR TITLE
fix(overflow): add missing toggle button to docs/ live viewer

### DIFF
--- a/docs/PowerCAT-Overflow.html
+++ b/docs/PowerCAT-Overflow.html
@@ -1448,8 +1448,9 @@ main.layout.editor-collapsed .editor-toggle-btn { transform: rotate(180deg); }
   </nav>
   <section class="editor-pane">
     <div class="editor-header">
-      <span>Workflow Definition (JSON)</span>
+      <span class="editor-title">Workflow Definition (JSON)</span>
       <span class="hint">Auto-updates as you type</span>
+      <button class="editor-toggle-btn" id="editorToggleBtn" title="Collapse code viewer" aria-label="Toggle code viewer">&#x25C0;</button>
     </div>
     <div id="jsonEditor"></div>
     <div class="error-message" id="errorMessage"></div>


### PR DESCRIPTION
## What this fixes

PR #24 added the collapsible editor toggle to `Common/PowerCAT OverFlow/PowerCAT-Overflow.html` correctly, but `docs/PowerCAT-Overflow.html` (the live GitHub Pages viewer) only received the CSS and JS — the `<button id="editorToggleBtn">` HTML element was never inserted into the markup. As a result the collapse button was invisible to all users hitting the live URL.

## Change

Single edit to `docs/PowerCAT-Overflow.html` (+2/−1):
- Wrap the title span with `class="editor-title"` (needed for the collapsed CSS to hide just the title)
- Add `<button class="editor-toggle-btn" id="editorToggleBtn" ...>&#x25C0;</button>` to the editor-header

No change to `Common/` copy — it already has the button from PR #24.