### PR TITLE
Add PowerCAT OverPage best-practice sources list

### DIFF
--- a/Common/PowerCAT OverPage/sources.md
+++ b/Common/PowerCAT OverPage/sources.md
@@ -1,0 +1,58 @@
+## Base Best Practices
+
+- [power-pages-docs-hub](https://learn.microsoft.com/power-pages/)
+- [power-pages-faq](https://learn.microsoft.com/power-pages/faq)
+- [power-pages-security](https://learn.microsoft.com/power-pages/security/power-pages-security)
+- [table-permissions](https://learn.microsoft.com/power-pages/security/table-permissions)
+- [page-security](https://learn.microsoft.com/power-pages/security/page-security)
+- [create-web-roles](https://learn.microsoft.com/power-pages/security/create-web-roles)
+- [web-application-firewall](https://learn.microsoft.com/power-pages/security/web-application-firewall)
+- [security-scan](https://learn.microsoft.com/power-pages/security/security-scan)
+- [site-checker-performance](https://learn.microsoft.com/power-pages/admin/site-checker-performance)
+- [configure-cdn](https://learn.microsoft.com/power-pages/configure/configure-cdn)
+- [well-architected](https://learn.microsoft.com/power-platform/well-architected/)
+- [wcag22](https://www.w3.org/TR/WCAG22/)
+
+## Security
+
+- [Power Pages security overview](https://learn.microsoft.com/power-pages/security/power-pages-security)
+- [Table permissions (Global / Contact / Account / Self access)](https://learn.microsoft.com/power-pages/security/table-permissions)
+- [Assign table permissions to web roles](https://learn.microsoft.com/power-pages/security/assign-table-permissions)
+- [Page permissions (web page access control rules)](https://learn.microsoft.com/power-pages/security/page-security)
+- [Create web roles (Authenticated vs Anonymous Users role)](https://learn.microsoft.com/power-pages/security/create-web-roles)
+- [Site visibility](https://learn.microsoft.com/power-pages/security/site-visibility)
+- [Authentication overview](https://learn.microsoft.com/power-pages/security/authentication/)
+- [Power Pages identity strategy & authentication best practices (Dynamics Community blog)](https://community.dynamics.com/blogs/post/?postid=1dd4444c-2602-4600-b34e-736b2be52b75)
+- [Web Application Firewall for Power Pages](https://learn.microsoft.com/power-pages/security/web-application-firewall)
+- [Configure managed rules in WAF](https://learn.microsoft.com/power-pages/security/configure-managed-rules)
+- [Security scan (preview)](https://learn.microsoft.com/power-pages/security/security-scan)
+- [Use the Security workspace](https://learn.microsoft.com/power-pages/getting-started/use-security-workspace)
+- [HTTP headers and site checker (security)](https://learn.microsoft.com/power-pages/security/site-checker-security)
+- [Power Pages security FAQ](https://learn.microsoft.com/power-pages/security/faq)
+- [Tutorial: Display data securely on your site](https://learn.microsoft.com/power-pages/getting-started/tutorial-display-data-securely)
+- [Power Pages Security white paper](https://learn.microsoft.com/power-pages/guidance/white-papers/security)
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+
+## Accessibility
+
+- [Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/TR/WCAG22/)
+- [WCAG 2.2 quick reference (how to meet)](https://www.w3.org/WAI/WCAG22/quickref/)
+
+## Performance
+
+- [Site Checker (self-service diagnostics)](https://learn.microsoft.com/power-pages/admin/site-checker)
+- [Site Checker — performance issues (caching, tracking, web file count)](https://learn.microsoft.com/power-pages/admin/site-checker-performance)
+- [Site Checker — configuration issues](https://learn.microsoft.com/power-pages/admin/site-checker-configuration-issues)
+- [Configure Content Delivery Network (CDN)](https://learn.microsoft.com/power-pages/configure/configure-cdn)
+- [Enable header and footer output caching](https://learn.microsoft.com/power-apps/maker/portals/configure/enable-header-footer-output-caching)
+
+## Maintainability, Architecture & Reliability
+
+- [Power Platform Well-Architected](https://learn.microsoft.com/power-platform/well-architected/)
+- [Power Pages Architecture white paper](https://learn.microsoft.com/power-pages/guidance/white-papers/architecture)
+- [Web templates (Liquid)](https://learn.microsoft.com/power-pages/configure/web-templates)
+- [Liquid overview](https://learn.microsoft.com/power-pages/configure/liquid-overview)
+- [Store content as web files](https://learn.microsoft.com/power-pages/configure/advanced-config)
+- [Site settings reference](https://learn.microsoft.com/power-apps/maker/portals/configure/configure-site-settings)
+- [Power Platform Application Lifecycle Management (ALM)](https://learn.microsoft.com/power-platform/alm/)
+- [Power Pages and the Power Platform CLI](https://learn.microsoft.com/power-pages/configure/power-platform-cli-tutorial)


### PR DESCRIPTION
Adds `Common/PowerCAT OverPage/sources.md` — the authoritative best-practice source list for the **PowerCAT OverPage** skill (Power Pages site review), mirroring the existing `Common/PowerCAT OverFlow/sources.md` pattern used by PowerCAT OverFlow.

Every link was verified to resolve (HTTP 200) before submission. Sources are grouped by review category:

- **Security** — Power Pages security model, table/page permissions, web roles, WAF, security scan, identity strategy, OWASP Top 10
- **Accessibility** — WCAG 2.2 (W3C)
- **Performance** — Site Checker (performance + configuration), CDN, output caching
- **Maintainability / Architecture / Reliability** — Well-Architected, architecture white paper, Liquid/web templates, site settings, ALM, Power Platform CLI

These URLs are the only citations the OverPage skill is allowed to anchor findings to.