### PR TITLE
fix(overflow): guard setWidth() so collapse actually works

### DIFF
--- a/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
+++ b/Common/PowerCAT OverFlow/PowerCAT-Overflow.html
@@ -3576,6 +3576,7 @@ function initSplitter() {
     return Math.max(MIN, window.innerWidth - MAX_FROM_RIGHT);
   }
   function setWidth(px) {
+    if (layout.classList.contains("editor-collapsed")) return;
     const clamped = Math.max(MIN, Math.min(maxAllowed(), Math.round(px)));
     layout.style.setProperty("--editor-width", clamped + "px");
     if (typeof aceEditor !== "undefined" && aceEditor) aceEditor.resize();

--- a/docs/PowerCAT-Overflow.html
+++ b/docs/PowerCAT-Overflow.html
@@ -3576,6 +3576,7 @@ function initSplitter() {
     return Math.max(MIN, window.innerWidth - MAX_FROM_RIGHT);
   }
   function setWidth(px) {
+    if (layout.classList.contains("editor-collapsed")) return;
     const clamped = Math.max(MIN, Math.min(maxAllowed(), Math.round(px)));
     layout.style.setProperty("--editor-width", clamped + "px");
     if (typeof aceEditor !== "undefined" && aceEditor) aceEditor.resize();


### PR DESCRIPTION
## Root cause

When the page loads with the editor collapsed (from localStorage), `initSplitter` calls `setWidth(savedWidth)` to restore the persisted width. This ran **after** `applyCollapsed` had already set `--editor-width: 0px`, clobbering it. The grid column snapped back to 380px, but with `.editor-pane { display:none }` the entire left area went blank — the designer never got the space.

## Fix

One line added to the top of `setWidth()`:
```js
if (layout.classList.contains('editor-collapsed')) return;
```n
This makes every call to `setWidth()` — startup restore, splitter drag, window resize — a no-op while collapsed. `applyCollapsed()` continues to drive `--editor-width` directly (0px on collapse, saved value on expand), so the grid track collapses correctly and the canvas-pane expands to fill the width.

## Files
`Common/PowerCAT OverFlow/PowerCAT-Overflow.html` + `docs/PowerCAT-Overflow.html` — +1 line each.