### PR TITLE
Expose Access migration as Copilot skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,10 +44,11 @@
       "description": "Power Platform Migration Factory skills for modernizing legacy forms and app data sources into Power Apps and Dataverse.",
       "source": "./Power Platform Migration Factory",
       "skills": [
+        "./Power Platform Migration Factory/Access to Dataverse Migration",
         "./Power Platform Migration Factory/infopath-to-canvas",
         "./Power Platform Migration Factory/migrate-to-dataverse"
       ],
-      "version": "1.0.0",
+      "version": "1.0.1",
       "repository": "https://github.com/microsoft/power-cat-skills",
       "license": "MIT",
       "category": "development",

--- a/Power Platform Migration Factory/.claude-plugin/plugin.json
+++ b/Power Platform Migration Factory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "powercat-migration-factory",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Power Platform Migration Factory skills for modernizing legacy forms and app data sources into Power Apps and Dataverse.",
   "author": {
     "name": "Microsoft",
@@ -9,6 +9,11 @@
   "homepage": "https://github.com/microsoft/power-cat-skills/",
   "repository": "https://github.com/microsoft/power-cat-skills/",
   "license": "MIT",
+  "skills": [
+    "Access to Dataverse Migration",
+    "infopath-to-canvas",
+    "migrate-to-dataverse"
+  ],
   "keywords": [
     "migration",
     "power-platform",

--- a/Power Platform Migration Factory/Access to Dataverse Migration/README.md
+++ b/Power Platform Migration Factory/Access to Dataverse Migration/README.md
@@ -7,13 +7,9 @@ the `access-to-dataverse` reference skill — one source of truth, a friendlier 
 
 ## One-time setup
 
-From the skill root (the folder that contains `requirements.txt`), run once to install Python
-dependencies and confirm `pac` / Node are present:
-
-```bash
-pip install -r requirements.txt
-python scripts/doctor.py
-```
+Install the Power Platform CLI (`pac`) and confirm Python 3.10+ is available. For live `.mdb`/`.accdb`
+reads, install `pyodbc` and the Microsoft Access Database Engine ODBC driver. If the driver is not
+available, export each Access table to `<Table>.csv` and set `source.type: csv` in `mapping.yaml`.
 
 ## How to call it
 
@@ -25,20 +21,14 @@ python scripts/doctor.py
 
 **Direct CLI (what the skill runs under the hood):**
 ```bash
-# 1) Configure target + branding (never commit these):
-cp config/environment.example.yaml config/environment.yaml
-cp config/branding.example.yaml   config/branding.yaml
+# 1) Sign in to the target Dataverse environment:
 pac auth create --environment https://YOUR-ORG.crm.dynamics.com
 
-# 2) Point the mapping at your database (edit skills/powercat-accessmigration/mapping.yaml:
-#    set source.path to your .mdb and adjust tables/columns/relationships), then:
-python -m factory run      powercat-accessmigration --mapping skills/powercat-accessmigration/mapping.yaml --env config/environment.yaml --dry-run   # preview, no writes
-python -m factory run      powercat-accessmigration --mapping skills/powercat-accessmigration/mapping.yaml --env config/environment.yaml             # execute
-python -m factory evaluate powercat-accessmigration
-python -m factory document powercat-accessmigration --branding config/branding.yaml
+# 2) Point the included mapping at your database:
+#    edit "Access to Dataverse Migration/mapping.yaml"
+#    set source.path to your .mdb/.accdb or CSV export folder
+#    adjust tables, columns, and relationships for your source schema
 ```
-
-`python -m factory list` shows this workload alongside `access-to-dataverse`.
 
 ## Prerequisites
 

--- a/Power Platform Migration Factory/Access to Dataverse Migration/SKILL.md
+++ b/Power Platform Migration Factory/Access to Dataverse Migration/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: powercat-accessmigration
+version: 1.0.0
+description: Migrate a Microsoft Access database (.mdb/.accdb) into Microsoft Dataverse with an optional model-driven app. USE WHEN the user wants to modernize an Access database, reverse-engineer Access tables into Dataverse, or run the PowerCAT Access Migration workflow.
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, PowerShell, Agent, TaskCreate, TaskUpdate, TaskList, Skill, EnterPlanMode, ExitPlanMode
+---
+
+# PowerCAT Access Migration
+
+Migrate the Microsoft Access database described below into Dataverse:
+
+$ARGUMENTS
+
+Use this skill when the user wants to migrate a `.mdb` or `.accdb` Access database to Microsoft Dataverse, with an optional model-driven app.
+
+## Workflow
+
+1. Resolve the source Access database path from `$ARGUMENTS`. If the user provided a folder, search for `.mdb` and `.accdb` files and ask which one to use if there are multiple.
+2. Read `${CLAUDE_PLUGIN_ROOT}/Access to Dataverse Migration/README.md` and `${CLAUDE_PLUGIN_ROOT}/Access to Dataverse Migration/mapping.yaml` before planning the migration.
+3. Create a migration plan covering source inventory, proposed Dataverse tables, columns, relationships, publisher prefix, solution name, app name, risks, and prerequisites.
+4. Ask the user to approve or adjust the plan before running any command that writes to Dataverse.
+5. If the user approves execution, use the included mapping as a starting point and update it for the actual Access database schema.
+6. Prefer a dry run or preview first. Only run live Dataverse writes after explicit user confirmation.
+
+## Important safeguards
+
+- Never commit local environment files, credentials, Access databases, exported CSV data, or generated run artifacts.
+- Confirm the target Dataverse environment before provisioning.
+- If the Access ODBC driver is unavailable, ask the user to export each table to CSV and set `source.type: csv` in the mapping.
+- Treat PII, payment, and sensitive source columns as review items before migration.
+

--- a/docs/power-platform-migration-factory/data/catalog.json
+++ b/docs/power-platform-migration-factory/data/catalog.json
@@ -359,16 +359,6 @@
   ],
   "migrationTracks": [
     {
-      "id": "Access to Dataverse Migration",
-      "title": "Access to Dataverse Migration",
-      "description": "The **named Access-to-Dataverse entry point** of the migration factory. It migrates a Microsoft Access database (`.mdb`/`.accdb`) into a Dataverse solution and, when `app.name` is…",
-      "status": "Coming soon",
-      "cta": "Coming soon",
-      "kind": "track",
-      "skillId": null,
-      "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Access%20to%20Dataverse%20Migration"
-    },
-    {
       "id": "Airtable to Power Platform Migration",
       "title": "Airtable to Power Platform Migration",
       "description": "This folder is reserved for the Airtable to Power Platform migration track in the Power Platform Migration Factory.",
@@ -399,6 +389,17 @@
       "skillId": "migrate-to-dataverse",
       "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/migrate-to-dataverse",
       "detailId": "powercat-migration-factory__migrate-to-dataverse"
+    },
+    {
+      "id": "powercat-accessmigration",
+      "title": "powercat-accessmigration",
+      "description": "Migrate a Microsoft Access database (.mdb/.accdb) into Microsoft Dataverse with an optional model-driven app.",
+      "status": "Available skill",
+      "cta": "Available skill",
+      "kind": "skill",
+      "skillId": "powercat-accessmigration",
+      "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Access%20to%20Dataverse%20Migration",
+      "detailId": null
     }
   ],
   "details": {
@@ -709,6 +710,34 @@
       "install": "copilot plugin install powercat-overpage@power-cat-skills",
       "source": "https://github.com/microsoft/power-cat-skills/tree/main/plugins/powercat-overpage/skills/powercat-overpage",
       "heading": "PowerCAT OverPage"
+    },
+    "powercat-migration-factory__Access to Dataverse Migration": {
+      "id": "Access to Dataverse Migration",
+      "detailId": "powercat-migration-factory__Access to Dataverse Migration",
+      "title": "Access to Dataverse Migration",
+      "category": "migration factory",
+      "plugin": "powercat-migration-factory",
+      "pluginLabel": "migration factory",
+      "description": "Migrate a Microsoft Access database (.mdb/.accdb) into Microsoft Dataverse with an optional model-driven app.",
+      "tags": [
+        "migration factory",
+        "migration",
+        "power platform"
+      ],
+      "what": "Migrate a Microsoft Access database (.mdb/.accdb) into Microsoft Dataverse with an optional model-driven app.",
+      "when": [
+        "Use this when you need migrate a Microsoft Access database (.mdb/.accdb) into Microsoft Dataverse with an optional model-driven app.",
+        "Use it when the work belongs in the migration factory area of the Power CAT marketplace.",
+        "Use it when you want a guided workflow instead of starting from a blank prompt."
+      ],
+      "how": [
+        "Guides the agent through a repeatable Power CAT delivery pattern.",
+        "Structures inputs, decisions, and outputs so the work is easier to review.",
+        "Links back to the source skill so teams can inspect or extend the workflow."
+      ],
+      "install": "copilot plugin install powercat-migration-factory@power-cat-skills",
+      "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Access%20to%20Dataverse%20Migration",
+      "heading": "PowerCAT Access Migration"
     },
     "powercat-migration-factory__infopath-to-canvas": {
       "id": "infopath-to-canvas",


### PR DESCRIPTION
## Summary
- add a SKILL.md wrapper for /powercat-accessmigration
- declare the Access migration folder in plugin and marketplace skill paths
- bump powercat-migration-factory to v1.0.1
- remove README setup commands that referenced files not present in the public plugin package

## Validation
- installed the local plugin into a clean COPILOT_HOME
- confirmed Copilot reports Installed 3 skills and lists powercat-accessmigration