### PR TITLE
Fix Migration Factory page labels

### DIFF
--- a/docs/power-platform-migration-factory/data/catalog.json
+++ b/docs/power-platform-migration-factory/data/catalog.json
@@ -24,6 +24,10 @@
     {
       "id": "adoption-storytelling",
       "label": "Adoption & Storytelling"
+    },
+    {
+      "id": "migration-power-platform",
+      "label": "Migration to Power Platform"
     }
   ],
   "plugins": [
@@ -1212,9 +1216,9 @@
       "id": "Access to Dataverse Migration",
       "detailId": "powercat-migration-factory__Access to Dataverse Migration",
       "title": "Access to Dataverse Migration",
-      "category": "Adoption & Storytelling",
-      "categoryId": "adoption-storytelling",
-      "categoryLabel": "Adoption & Storytelling",
+      "category": "Migration to Power Platform",
+      "categoryId": "migration-power-platform",
+      "categoryLabel": "Migration to Power Platform",
       "plugin": "powercat-migration-factory",
       "pluginLabel": "migration factory",
       "description": "The **named Access-to-Dataverse entry point** of the migration factory. It migrates a Microsoft Access database (`.mdb`/`.accdb`) into a Dataverse solution and, when `app.name` is…",
@@ -1251,9 +1255,9 @@
       "id": "infopath-to-canvas",
       "detailId": "powercat-migration-factory__infopath-to-canvas",
       "title": "infopath-to-canvas",
-      "category": "Adoption & Storytelling",
-      "categoryId": "adoption-storytelling",
-      "categoryLabel": "Adoption & Storytelling",
+      "category": "Migration to Power Platform",
+      "categoryId": "migration-power-platform",
+      "categoryLabel": "Migration to Power Platform",
       "plugin": "powercat-migration-factory",
       "pluginLabel": "migration factory",
       "description": "Assess InfoPath forms, identify fields, rules, views, submit behavior, and workflow dependencies, then shape a Canvas App modernization plan with migration risks called out early.",
@@ -1291,9 +1295,9 @@
       "id": "migrate-to-dataverse",
       "detailId": "powercat-migration-factory__migrate-to-dataverse",
       "title": "migrate-to-dataverse",
-      "category": "Adoption & Storytelling",
-      "categoryId": "adoption-storytelling",
-      "categoryLabel": "Adoption & Storytelling",
+      "category": "Migration to Power Platform",
+      "categoryId": "migration-power-platform",
+      "categoryLabel": "Migration to Power Platform",
       "plugin": "powercat-migration-factory",
       "pluginLabel": "migration factory",
       "description": "Analyze SharePoint list-backed app data sources, recommend Dataverse table mappings, and document the app, security, relationship, and ALM changes needed for a safer migration.",

--- a/docs/power-platform-migration-factory/index.html
+++ b/docs/power-platform-migration-factory/index.html
@@ -265,7 +265,7 @@
       <a href="#skills">Skills</a>
       <a href="#install">Install</a>
       <div class="theme-switch" aria-label="Theme">
-        <button class="theme-choice" type="button" data-theme-choice="light" aria-pressed="false">Current</button>
+        <button class="theme-choice" type="button" data-theme-choice="light" aria-pressed="false">Light</button>
         <button class="theme-choice" type="button" data-theme-choice="dark" aria-pressed="false">Dark</button>
         <button class="theme-choice" type="button" data-theme-choice="portal" aria-pressed="false">Portal</button>
       </div>

--- a/docs/power-platform-migration-factory/skill-details.html
+++ b/docs/power-platform-migration-factory/skill-details.html
@@ -29,7 +29,7 @@
       <a href="index.html#skills">Skills</a>
       <a href="index.html#install">Install</a>
       <div class="theme-switch" aria-label="Theme">
-        <button class="theme-choice" type="button" data-theme-choice="light" aria-pressed="false">Current</button>
+        <button class="theme-choice" type="button" data-theme-choice="light" aria-pressed="false">Light</button>
         <button class="theme-choice" type="button" data-theme-choice="dark" aria-pressed="false">Dark</button>
         <button class="theme-choice" type="button" data-theme-choice="portal" aria-pressed="false">Portal</button>
       </div>

--- a/docs/power-platform-migration-factory/skill.html
+++ b/docs/power-platform-migration-factory/skill.html
@@ -29,7 +29,7 @@
       <a href="index.html#skills">Skills</a>
       <a href="index.html#install">Install</a>
       <div class="theme-switch" aria-label="Theme">
-        <button class="theme-choice" type="button" data-theme-choice="light" aria-pressed="false">Current</button>
+        <button class="theme-choice" type="button" data-theme-choice="light" aria-pressed="false">Light</button>
         <button class="theme-choice" type="button" data-theme-choice="dark" aria-pressed="false">Dark</button>
         <button class="theme-choice" type="button" data-theme-choice="portal" aria-pressed="false">Portal</button>
       </div>

--- a/scripts/build-pages-catalog.js
+++ b/scripts/build-pages-catalog.js
@@ -44,6 +44,10 @@ const categories = [
     id: "adoption-storytelling",
     label: "Adoption & Storytelling",
   },
+  {
+    id: "migration-power-platform",
+    label: "Migration to Power Platform",
+  },
 ];
 
 const skillCategories = {
@@ -593,7 +597,13 @@ function buildCatalog() {
   const migrationSkills = migrationPlugin
     ? migrationPlugin.skills.map((skillPath) => {
         const skill = skillFromPath(skillPath, migrationPlugin);
-        return { ...skill, ...(skillOverrides[skill.id] || {}) };
+        return {
+          ...skill,
+          category: "Migration to Power Platform",
+          categoryId: "migration-power-platform",
+          categoryLabel: "Migration to Power Platform",
+          ...(skillOverrides[skill.id] || {}),
+        };
       })
     : [];
 


### PR DESCRIPTION
## Summary
- Show Migration Factory skill pages under Migration to Power Platform
- Rename the light theme toggle from Current to Light
- Regenerate the Migration Factory catalog

## Validation
- Ran `node scripts/build-pages-catalog.js`
- Verified Access and migrate-to-Dataverse categories resolve to Migration to Power Platform
- Verified theme label appears as Light on home, overview, and detail pages