### PR TITLE
Generate details for Migration Factory folders

### DIFF
--- a/docs/power-platform-migration-factory/data/catalog.json
+++ b/docs/power-platform-migration-factory/data/catalog.json
@@ -648,7 +648,7 @@
       "kind": "skill",
       "skillId": "Airtable to Power Platform Migration",
       "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Airtable%20to%20Power%20Platform%20Migration",
-      "detailId": null
+      "detailId": "powercat-migration-factory__Airtable to Power Platform Migration"
     },
     {
       "id": "infopath-to-canvas",
@@ -1335,6 +1335,45 @@
       "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/migrate-to-dataverse",
       "heading": "Workload: Migrate Canvas App Data Sources to Dataverse (`migrate-to-dataverse`)",
       "cardCta": "Dataverse migration skill"
+    },
+    "powercat-migration-factory__Airtable to Power Platform Migration": {
+      "id": "Airtable to Power Platform Migration",
+      "detailId": "powercat-migration-factory__Airtable to Power Platform Migration",
+      "title": "Airtable to Power Platform Migration",
+      "category": "Migration to Power Platform",
+      "categoryId": "migration-power-platform",
+      "categoryLabel": "Migration to Power Platform",
+      "plugin": "powercat-migration-factory",
+      "pluginLabel": "migration factory",
+      "description": "Migrate an Airtable app into Microsoft platform targets:",
+      "tags": [
+        "migration factory",
+        "migration",
+        "power platform"
+      ],
+      "products": [
+        {
+          "label": "Power Platform",
+          "icon": "assets/product-icons/power-platform.svg"
+        }
+      ],
+      "images": [],
+      "docsHtml": "<h2>Airtable to Microsoft App Modernization</h2>\n<p>Migrate an Airtable app into Microsoft platform targets:</p>\n<ul><li>Dataverse tables</li><li>SharePoint Lists</li><li>Code App scaffold</li><li>Canvas App scaffold</li><li>Power Automate draft flows</li></ul>\n<p>This is an agent-driven migration skill. Start with <a href=\"./SKILL.md\" target=\"_blank\" rel=\"noopener\"><code>SKILL.md</code></a>, then use <a href=\"./HOW-TO-USE.md\" target=\"_blank\" rel=\"noopener\"><code>HOW-TO-USE.md</code></a> for prerequisites and step-by-step operator guidance.</p>\n<h3>Scope</h3>\n<p>The skill owns the end-to-end migration flow:</p>\n<ul><li>Export Airtable schema and data through a secure local PowerShell prompt.</li><li>Analyze fields, relationships, choices, AI fields, person fields, records, and attachments.</li><li>Ask whether the target data platform is Dataverse, SharePoint Lists, both, or plan-only.</li><li>Collect target environment/site and solution/list details before creating artifacts.</li><li>Create Dataverse tables/data through Dataverse MCP when selected.</li><li>Create SharePoint Lists/data through SharePoint/Graph MCP or PnP PowerShell when selected.</li><li>Optionally generate Code App, Canvas App, and Power Automate draft-flow plans.</li><li>Produce JSON artifacts and user-friendly DOCX reports when document tooling is available.</li></ul>\n<h3>Important safety notes</h3>\n<ul><li>Do not paste Airtable tokens, Dataverse tokens, SharePoint tokens, passwords, or secrets into chat.</li><li>Airtable token entry must use <code>Read-Host -AsSecureString</code>.</li><li>Dataverse auth must use Dataverse MCP or an approved local auth path.</li><li>SharePoint auth must use SharePoint/Graph MCP, PnP PowerShell interactive auth, or an approved local auth path.</li><li>All writes are approval-gated at phase boundaries.</li></ul>\n<h3>How to run</h3>\n<p>Use one of these paths:</p>\n<ul><li>Invoke the installed skill, if available:</li></ul>\n<pre><code>/powercat-airtablemigration</code></pre>\n<ul><li>Or clone/open this folder from the repo:</li></ul>\n<pre><code>git clone https://github.com/microsoft/Power-CAT-Skills-Internal.git\ncd &quot;Power-CAT-Skills-Internal\\plugins\\powercat-powerplatform-migration-factory\\skills\\powercat-powerplatform-migration-factory\\skills\\powercat-airtablemigration&quot;</code></pre>\n<p>Then prompt:</p>\n<pre><code>Use SKILL.md. Start a fresh Airtable migration run.</code></pre>\n<p>For detailed instructions, see <a href=\"./HOW-TO-USE.md\" target=\"_blank\" rel=\"noopener\"><code>HOW-TO-USE.md</code></a>.</p>",
+      "docsSource": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Airtable%20to%20Power%20Platform%20Migration/README.md",
+      "what": "Migrate an Airtable app into Microsoft platform targets:",
+      "when": [
+        "Use this when you need migrate an Airtable app into Microsoft platform targets:",
+        "Use it when the work belongs in Adoption & Storytelling.",
+        "Use it when you want a guided workflow instead of starting from a blank prompt."
+      ],
+      "how": [
+        "Guides the agent through a repeatable Power CAT delivery pattern.",
+        "Structures inputs, decisions, and outputs so the work is easier to review.",
+        "Links back to the source skill so teams can inspect or extend the workflow."
+      ],
+      "install": "copilot plugin install powercat-migration-factory@power-cat-skills",
+      "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Airtable%20to%20Power%20Platform%20Migration",
+      "heading": "Airtable to Microsoft App Modernization"
     }
   }
 }

--- a/scripts/build-pages-catalog.js
+++ b/scripts/build-pages-catalog.js
@@ -541,6 +541,17 @@ function skillFromPath(skillPath, plugin) {
   };
 }
 
+function migrationSkillFromPath(skillPath, plugin) {
+  const skill = skillFromPath(skillPath, plugin);
+  return {
+    ...skill,
+    category: "Migration to Power Platform",
+    categoryId: "migration-power-platform",
+    categoryLabel: "Migration to Power Platform",
+    ...(skillOverrides[skill.id] || {}),
+  };
+}
+
 function migrationTrackFromFolder(folder) {
   const fullPath = path.join(migrationRoot, folder);
   const readmePath = path.join(fullPath, "README.md");
@@ -594,17 +605,19 @@ function buildCatalog() {
     .flatMap((plugin) => (plugin.skills || []).map((skillPath) => skillFromPath(skillPath, plugin)));
 
   const migrationPlugin = marketplace.plugins.find((plugin) => plugin.name === "powercat-migration-factory");
+  const migrationFolderSkillPaths = fs
+    .readdirSync(migrationRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .map((entry) => path.relative(root, path.join(migrationRoot, entry.name)))
+    .filter((skillPath) => {
+      const fullPath = path.join(root, skillPath);
+      return fs.existsSync(path.join(fullPath, "README.md")) || fs.existsSync(path.join(fullPath, "SKILL.md"));
+    });
+  const migrationSkillPaths = migrationPlugin
+    ? [...new Set([...(migrationPlugin.skills || []), ...migrationFolderSkillPaths])]
+    : migrationFolderSkillPaths;
   const migrationSkills = migrationPlugin
-    ? migrationPlugin.skills.map((skillPath) => {
-        const skill = skillFromPath(skillPath, migrationPlugin);
-        return {
-          ...skill,
-          category: "Migration to Power Platform",
-          categoryId: "migration-power-platform",
-          categoryLabel: "Migration to Power Platform",
-          ...(skillOverrides[skill.id] || {}),
-        };
-      })
+    ? migrationSkillPaths.map((skillPath) => migrationSkillFromPath(skillPath, migrationPlugin))
     : [];
 
   const migrationSkillIds = new Set(migrationSkills.map((skill) => skill.id));


### PR DESCRIPTION
## Summary
- Generate detail records for every Migration Factory folder with README/SKILL content
- Make new migration folders such as Airtable automatically link to generated overview and README detail pages
- Regenerate the Pages catalog with the Airtable migration detail entry

## Validation
- Ran `node scripts/build-pages-catalog.js`
- Verified Airtable migration has a generated detailId and README-backed docsSource
- Verified local preview URLs returned 200