### PR TITLE
Add Airtable migration to plugin metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,16 +45,17 @@
       "source": "./Power Platform Migration Factory",
       "skills": [
         "./Power Platform Migration Factory/Access to Dataverse Migration",
+        "./Power Platform Migration Factory/Airtable to Power Platform Migration",
         "./Power Platform Migration Factory/infopath-to-canvas",
         "./Power Platform Migration Factory/migrate-to-dataverse"
       ],
-      "version": "1.0.1",
+      "version": "1.0.2",
       "repository": "https://github.com/microsoft/power-cat-skills",
       "license": "MIT",
       "category": "development",
       "tags": [
         "migration", "power platform", "power apps",
-        "infopath", "dataverse", "sharepoint lists",
+        "airtable", "infopath", "dataverse", "sharepoint lists",
         "microsoft power platform", "microsoft"
       ]
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ power-cat-skills/
 │       └── skills/
 │           └── create-pp-dev-env/            # Provision a Developer environment via BAP API
 ├── Power Platform Migration Factory/         # Legacy-to-Power Platform migration plugin
+│   ├── Airtable to Power Platform Migration/ # Migrate Airtable apps to Microsoft platform targets
 │   ├── infopath-to-canvas/                   # Migrate InfoPath .xsn forms to Canvas Apps
 │   └── migrate-to-dataverse/                 # Replace SharePoint lists with Dataverse tables
 ├── shared/                   # Cross-plugin shared resources
@@ -43,6 +44,7 @@ power-cat-skills/
 |--------|-------|-------------|
 | `powercat-adoption` | `/powercat-storytelling` | Generate a polished 5-slide HTML customer story deck — brand-matched, self-contained, and presentation-ready |
 | `powercat-canvas-apps` | `/analyze-canvas-performance` | Code review and performance audit of Canvas App pa.yaml files |
+| `powercat-migration-factory` | `/powercat-airtablemigration` | Migrate Airtable apps to Dataverse, SharePoint Lists, app scaffolds, and Power Automate draft-flow artifacts |
 | `powercat-migration-factory` | `/infopath-to-canvas` | Migrate InfoPath .xsn forms to Power Apps Canvas Apps |
 | `powercat-migration-factory` | `/migrate-to-dataverse` | Replace SharePoint list sources in a Canvas App with Dataverse tables |
 | `powercat-dataverse` | `/dataverse-webapi-query` | Author and ship Dataverse Web API queries — natural language → OData URL, FetchXML conversion, multi-surface targeting, error diagnosis |

--- a/Power Platform Migration Factory/.claude-plugin/plugin.json
+++ b/Power Platform Migration Factory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "powercat-migration-factory",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Power Platform Migration Factory skills for modernizing legacy forms and app data sources into Power Apps and Dataverse.",
   "author": {
     "name": "Microsoft",
@@ -11,11 +11,13 @@
   "license": "MIT",
   "skills": [
     "Access to Dataverse Migration",
+    "Airtable to Power Platform Migration",
     "infopath-to-canvas",
     "migrate-to-dataverse"
   ],
   "keywords": [
     "migration",
+    "airtable",
     "power-platform",
     "power-apps",
     "dataverse",

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A plugin marketplace for **Microsoft Scout** and **GitHub Copilot CLI** that pro
 
 | Skill | Description |
 |-------|-------------|
+| **Airtable to Power Platform Migration** | Migrate Airtable apps into Microsoft platform targets including Dataverse, SharePoint Lists, app scaffolds, and Power Automate draft flows |
 | **infopath-to-canvas** | Migrate InfoPath forms (.xsn) to modern Canvas Apps |
 | **migrate-to-dataverse** | Replace SharePoint list data sources with Dataverse table equivalents |
 

--- a/docs/power-platform-migration-factory/data/catalog.json
+++ b/docs/power-platform-migration-factory/data/catalog.json
@@ -1252,6 +1252,45 @@
       "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Access%20to%20Dataverse%20Migration",
       "heading": "Workload: PowerCAT Access Migration (`powercat-accessmigration`)"
     },
+    "powercat-migration-factory__Airtable to Power Platform Migration": {
+      "id": "Airtable to Power Platform Migration",
+      "detailId": "powercat-migration-factory__Airtable to Power Platform Migration",
+      "title": "Airtable to Power Platform Migration",
+      "category": "Migration to Power Platform",
+      "categoryId": "migration-power-platform",
+      "categoryLabel": "Migration to Power Platform",
+      "plugin": "powercat-migration-factory",
+      "pluginLabel": "migration factory",
+      "description": "Migrate an Airtable app into Microsoft platform targets:",
+      "tags": [
+        "migration factory",
+        "migration",
+        "power platform"
+      ],
+      "products": [
+        {
+          "label": "Power Platform",
+          "icon": "assets/product-icons/power-platform.svg"
+        }
+      ],
+      "images": [],
+      "docsHtml": "<h2>Airtable to Microsoft App Modernization</h2>\n<p>Migrate an Airtable app into Microsoft platform targets:</p>\n<ul><li>Dataverse tables</li><li>SharePoint Lists</li><li>Code App scaffold</li><li>Canvas App scaffold</li><li>Power Automate draft flows</li></ul>\n<p>This is an agent-driven migration skill. Start with <a href=\"./SKILL.md\" target=\"_blank\" rel=\"noopener\"><code>SKILL.md</code></a>, then use <a href=\"./HOW-TO-USE.md\" target=\"_blank\" rel=\"noopener\"><code>HOW-TO-USE.md</code></a> for prerequisites and step-by-step operator guidance.</p>\n<h3>Scope</h3>\n<p>The skill owns the end-to-end migration flow:</p>\n<ul><li>Export Airtable schema and data through a secure local PowerShell prompt.</li><li>Analyze fields, relationships, choices, AI fields, person fields, records, and attachments.</li><li>Ask whether the target data platform is Dataverse, SharePoint Lists, both, or plan-only.</li><li>Collect target environment/site and solution/list details before creating artifacts.</li><li>Create Dataverse tables/data through Dataverse MCP when selected.</li><li>Create SharePoint Lists/data through SharePoint/Graph MCP or PnP PowerShell when selected.</li><li>Optionally generate Code App, Canvas App, and Power Automate draft-flow plans.</li><li>Produce JSON artifacts and user-friendly DOCX reports when document tooling is available.</li></ul>\n<h3>Important safety notes</h3>\n<ul><li>Do not paste Airtable tokens, Dataverse tokens, SharePoint tokens, passwords, or secrets into chat.</li><li>Airtable token entry must use <code>Read-Host -AsSecureString</code>.</li><li>Dataverse auth must use Dataverse MCP or an approved local auth path.</li><li>SharePoint auth must use SharePoint/Graph MCP, PnP PowerShell interactive auth, or an approved local auth path.</li><li>All writes are approval-gated at phase boundaries.</li></ul>\n<h3>How to run</h3>\n<p>Use one of these paths:</p>\n<ul><li>Invoke the installed skill, if available:</li></ul>\n<pre><code>/powercat-airtablemigration</code></pre>\n<ul><li>Or clone/open this folder from the repo:</li></ul>\n<pre><code>git clone https://github.com/microsoft/Power-CAT-Skills-Internal.git\ncd &quot;Power-CAT-Skills-Internal\\plugins\\powercat-powerplatform-migration-factory\\skills\\powercat-powerplatform-migration-factory\\skills\\powercat-airtablemigration&quot;</code></pre>\n<p>Then prompt:</p>\n<pre><code>Use SKILL.md. Start a fresh Airtable migration run.</code></pre>\n<p>For detailed instructions, see <a href=\"./HOW-TO-USE.md\" target=\"_blank\" rel=\"noopener\"><code>HOW-TO-USE.md</code></a>.</p>",
+      "docsSource": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Airtable%20to%20Power%20Platform%20Migration/README.md",
+      "what": "Migrate an Airtable app into Microsoft platform targets:",
+      "when": [
+        "Use this when you need migrate an Airtable app into Microsoft platform targets:",
+        "Use it when the work belongs in Adoption & Storytelling.",
+        "Use it when you want a guided workflow instead of starting from a blank prompt."
+      ],
+      "how": [
+        "Guides the agent through a repeatable Power CAT delivery pattern.",
+        "Structures inputs, decisions, and outputs so the work is easier to review.",
+        "Links back to the source skill so teams can inspect or extend the workflow."
+      ],
+      "install": "copilot plugin install powercat-migration-factory@power-cat-skills",
+      "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Airtable%20to%20Power%20Platform%20Migration",
+      "heading": "Airtable to Microsoft App Modernization"
+    },
     "powercat-migration-factory__infopath-to-canvas": {
       "id": "infopath-to-canvas",
       "detailId": "powercat-migration-factory__infopath-to-canvas",
@@ -1335,45 +1374,6 @@
       "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/migrate-to-dataverse",
       "heading": "Workload: Migrate Canvas App Data Sources to Dataverse (`migrate-to-dataverse`)",
       "cardCta": "Dataverse migration skill"
-    },
-    "powercat-migration-factory__Airtable to Power Platform Migration": {
-      "id": "Airtable to Power Platform Migration",
-      "detailId": "powercat-migration-factory__Airtable to Power Platform Migration",
-      "title": "Airtable to Power Platform Migration",
-      "category": "Migration to Power Platform",
-      "categoryId": "migration-power-platform",
-      "categoryLabel": "Migration to Power Platform",
-      "plugin": "powercat-migration-factory",
-      "pluginLabel": "migration factory",
-      "description": "Migrate an Airtable app into Microsoft platform targets:",
-      "tags": [
-        "migration factory",
-        "migration",
-        "power platform"
-      ],
-      "products": [
-        {
-          "label": "Power Platform",
-          "icon": "assets/product-icons/power-platform.svg"
-        }
-      ],
-      "images": [],
-      "docsHtml": "<h2>Airtable to Microsoft App Modernization</h2>\n<p>Migrate an Airtable app into Microsoft platform targets:</p>\n<ul><li>Dataverse tables</li><li>SharePoint Lists</li><li>Code App scaffold</li><li>Canvas App scaffold</li><li>Power Automate draft flows</li></ul>\n<p>This is an agent-driven migration skill. Start with <a href=\"./SKILL.md\" target=\"_blank\" rel=\"noopener\"><code>SKILL.md</code></a>, then use <a href=\"./HOW-TO-USE.md\" target=\"_blank\" rel=\"noopener\"><code>HOW-TO-USE.md</code></a> for prerequisites and step-by-step operator guidance.</p>\n<h3>Scope</h3>\n<p>The skill owns the end-to-end migration flow:</p>\n<ul><li>Export Airtable schema and data through a secure local PowerShell prompt.</li><li>Analyze fields, relationships, choices, AI fields, person fields, records, and attachments.</li><li>Ask whether the target data platform is Dataverse, SharePoint Lists, both, or plan-only.</li><li>Collect target environment/site and solution/list details before creating artifacts.</li><li>Create Dataverse tables/data through Dataverse MCP when selected.</li><li>Create SharePoint Lists/data through SharePoint/Graph MCP or PnP PowerShell when selected.</li><li>Optionally generate Code App, Canvas App, and Power Automate draft-flow plans.</li><li>Produce JSON artifacts and user-friendly DOCX reports when document tooling is available.</li></ul>\n<h3>Important safety notes</h3>\n<ul><li>Do not paste Airtable tokens, Dataverse tokens, SharePoint tokens, passwords, or secrets into chat.</li><li>Airtable token entry must use <code>Read-Host -AsSecureString</code>.</li><li>Dataverse auth must use Dataverse MCP or an approved local auth path.</li><li>SharePoint auth must use SharePoint/Graph MCP, PnP PowerShell interactive auth, or an approved local auth path.</li><li>All writes are approval-gated at phase boundaries.</li></ul>\n<h3>How to run</h3>\n<p>Use one of these paths:</p>\n<ul><li>Invoke the installed skill, if available:</li></ul>\n<pre><code>/powercat-airtablemigration</code></pre>\n<ul><li>Or clone/open this folder from the repo:</li></ul>\n<pre><code>git clone https://github.com/microsoft/Power-CAT-Skills-Internal.git\ncd &quot;Power-CAT-Skills-Internal\\plugins\\powercat-powerplatform-migration-factory\\skills\\powercat-powerplatform-migration-factory\\skills\\powercat-airtablemigration&quot;</code></pre>\n<p>Then prompt:</p>\n<pre><code>Use SKILL.md. Start a fresh Airtable migration run.</code></pre>\n<p>For detailed instructions, see <a href=\"./HOW-TO-USE.md\" target=\"_blank\" rel=\"noopener\"><code>HOW-TO-USE.md</code></a>.</p>",
-      "docsSource": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Airtable%20to%20Power%20Platform%20Migration/README.md",
-      "what": "Migrate an Airtable app into Microsoft platform targets:",
-      "when": [
-        "Use this when you need migrate an Airtable app into Microsoft platform targets:",
-        "Use it when the work belongs in Adoption & Storytelling.",
-        "Use it when you want a guided workflow instead of starting from a blank prompt."
-      ],
-      "how": [
-        "Guides the agent through a repeatable Power CAT delivery pattern.",
-        "Structures inputs, decisions, and outputs so the work is easier to review.",
-        "Links back to the source skill so teams can inspect or extend the workflow."
-      ],
-      "install": "copilot plugin install powercat-migration-factory@power-cat-skills",
-      "source": "https://github.com/microsoft/power-cat-skills/tree/main/Power%20Platform%20Migration%20Factory/Airtable%20to%20Power%20Platform%20Migration",
-      "heading": "Airtable to Microsoft App Modernization"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add Airtable migration to the powercat-migration-factory plugin skills list
- Bump the migration factory plugin metadata version to 1.0.2
- Add Airtable to migration plugin keywords and docs tables
- Regenerate the Pages catalog

## Validation
- Ran `node scripts/build-pages-catalog.js`
- Verified Airtable appears once in generated detail entries
- Ran `git diff --check`